### PR TITLE
fix example

### DIFF
--- a/examples/websockets.js
+++ b/examples/websockets.js
@@ -1,6 +1,6 @@
-var BitfinexWS = require ('bitfinex-api-node').WS;
+var BitfinexWS = require ('bitfinex-api-node');
 
-var bws = new BitfinexWS();
+var bws = new BitfinexWS().ws;
 
 bws.on('open', function () {
     bws.subscribeTrades('BTCUSD');


### PR DESCRIPTION
the latest version of the websocket wrapper does exposes the
`.ws` property _after_ the main constructor function is called.


note: did not use ES6 constants as I am not sure how you hande ES6 in your examples.