### PR TITLE
orderbooks: add missing length parameter for WS

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ class BFX {
     if (version == 2) { // XXX make strict on next major version bump / breaking change
       this.rest = new REST2(this.apiKey, this.apiSecret)
       this.ws = new WS2(this.apiKey, this.apiSecret)
+      this.ws.open()
     } else {
       this.rest = new REST(this.apiKey, this.apiSecret)
       this.ws = new WS(this.apiKey, this.apiSecret)

--- a/test/ws-2-order-book.js
+++ b/test/ws-2-order-book.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+
+'use strict'
+const PORT = 1337
+
+const assert = require('assert')
+
+const WebSocket = require('ws')
+const BfxWs = require('../ws2.js')
+
+const API_KEY = 'dummy'
+const API_SECRET = 'dummy'
+
+describe('websocket order books', () => {
+  it('sends the length parameter', (done) => {
+    const bfxWs = new BfxWs(
+      API_KEY,
+      API_SECRET,
+      { websocketURI: `ws://localhost:${PORT}` }
+    )
+
+    bfxWs.open()
+
+    const wss = new WebSocket.Server({
+      perMessageDeflate: false,
+      port: PORT
+    })
+
+    wss.on('connection', function connection (ws) {
+      ws.on('message', function incoming (msg) {
+        msg = JSON.parse(msg)
+        assert.equal(msg.len, '25')
+        wss.close()
+        done()
+      })
+
+      ws.send('[{}]')
+    })
+
+    bfxWs.on('open', () => {
+      bfxWs.subscribeOrderBook('BTCUSD', 'R0')
+    })
+  })
+})

--- a/ws.js
+++ b/ws.js
@@ -344,7 +344,8 @@ BitfinexWS.prototype.subscribeOrderBook =
         event: 'subscribe',
         channel: 'book',
         pair,
-        prec: precision
+        prec: precision,
+        len: length
       })
     }
 

--- a/ws2.js
+++ b/ws2.js
@@ -13,12 +13,14 @@ const WebSocket = require('ws')
  * @class
  */
 class BitfinexWS2 extends EventEmitter {
-  constructor (apiKey, apiSecret) {
+  constructor (apiKey, apiSecret, opts = {}) {
     super()
-      // EventEmitter.call(this)
     this.apiKey = apiKey
     this.apiSecret = apiSecret
-    this.websocketURI = 'wss://api.bitfinex.com/ws/2'
+    this.websocketURI = opts.websocketURI || 'wss://api.bitfinex.com/ws/2'
+  }
+
+  open () {
     this.ws = new WebSocket(this.websocketURI)
     this.ws.on('message', this.onMessage.bind(this))
     this.ws.on('open', this.onOpen.bind(this))
@@ -182,6 +184,7 @@ class BitfinexWS2 extends EventEmitter {
       event: 'subscribe',
       channel: 'book',
       symbol,
+      len: length,
       prec: precision
     })
   }


### PR DESCRIPTION
changes to increase testability:

 - make url injectable
 - move creation of websocket connection out of constructor,
   make it callable (e.g. after calling `close`)

Closes #38