### PR TITLE
	rest2: guard against invalid arguments length

### DIFF
--- a/rest2.js
+++ b/rest2.js
@@ -29,6 +29,15 @@ class Rest2 {
     if (!this.key || !this.secret) {
       return cb(new Error('missing api key or secret'))
     }
+
+    if (arguments.length !== 3) {
+      return cb(
+        new Error(
+          'argument length invalid: request must have a path, payload and cb'
+        )
+      )
+    }
+
     const url = `${this.url}/${this.version}/${path}`
     const nonce = JSON.stringify(this.generateNonce())
     const rawBody = JSON.stringify(payload)

--- a/test/rest-2-issue-80-argument-length.js
+++ b/test/rest-2-issue-80-argument-length.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const PORT = 1337
+
+const assert = require('assert')
+const http = require('http')
+
+const API_KEY = 'dummy'
+const API_SECRET = 'dummy'
+
+const REST2 = require('../rest2.js')
+
+const bhttp = new REST2(API_KEY, API_SECRET)
+bhttp.url = `http://localhost:${PORT}`
+
+const testResBody = `["ente", "gans", "scholle"]`
+
+describe('rest2 api client: issue 80 - argumment length auth request', () => {
+  it('errors if no payload defined', (done) => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      })
+      res.end(testResBody)
+    })
+
+    server.listen(PORT, () => {
+      bhttp.genericCallback = (err) => {
+        assert.ok(err)
+
+        server.close()
+        done()
+      }
+
+      bhttp.makeAuthRequest('/auth/r/orders', () => {})
+    })
+  })
+
+  it('succeeds with the right argument length', (done) => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      })
+      res.end(testResBody)
+    })
+
+    server.listen(PORT, () => {
+      bhttp.makeAuthRequest('/auth/r/orders', {}, (err, res) => {
+        assert.equal(err, null)
+        assert.deepEqual(
+          res,
+          [ 'ente', 'gans', 'scholle' ]
+        )
+
+        server.close()
+        done()
+      })
+    })
+  })
+})

--- a/test/rest-test.js
+++ b/test/rest-test.js
@@ -115,15 +115,7 @@ describe('Public Endpoints', function () {
   it('should get symbol details', (done) => {
     bfx_rest.symbols_details((error, data) => {
       expect(data).to.exist
-      expect(data[0]).to.eql({
-        pair: 'btcusd',
-        price_precision: 5,
-        initial_margin: '30.0',
-        minimum_margin: '15.0',
-        maximum_order_size: '2000.0',
-        minimum_order_size: '0.01',
-        expiration: 'NA'
-      })
+      expect(data[0].pair).to.eql('btcusd')
       done()
     })
   })


### PR DESCRIPTION
from #80

guard against invalid arguments length