### PR TITLE
rest1: remove unsecure TLS config

### DIFF
--- a/rest.js
+++ b/rest.js
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
 const crypto = require('crypto')
 const request = require('request')
 


### PR DESCRIPTION
This might introduce pretty bad behaviors and security concerns in production. I believe this was for testing purposes and was not intended to stay there.