### PR TITLE
claim-positions: fix parsing

### DIFF
--- a/rest.js
+++ b/rest.js
@@ -266,7 +266,7 @@ rest.prototype.active_positions = function (cb) {
 rest.prototype.claim_position = function (position_id, amount, cb) {
   const params = {
     position_id: parseInt(position_id),
-    amount: parseInt(amount)
+    amount: amount
   }
   return this.make_request('position/claim', params, cb)
 }


### PR DESCRIPTION
we have to pass a decimal string, e.g. `'1.01'`