### PR TITLE
Added support for v2 trades and v1 BFX options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const WS2 = require('./ws2.js')
 const t = require('./lib/transformer.js')
 
 class BFX {
-  constructor (apiKey, apiSecret, opts = { version: 1, transform: false }) {
+  constructor (apiKey, apiSecret, opts = { version: 1, transform: false, nonceGenerator: false }) {
     this.apiKey = apiKey
     this.apiSecret = apiSecret
 
@@ -41,7 +41,7 @@ class BFX {
       return
     }
 
-    this.rest = new REST(this.apiKey, this.apiSecret)
+    this.rest = new REST(this.apiKey, this.apiSecret, opts)
     this.ws = new WS(this.apiKey, this.apiSecret)
     opts.autoOpen && this.ws.open()
   }

--- a/rest.js
+++ b/rest.js
@@ -5,16 +5,18 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 const crypto = require('crypto')
 const request = require('request')
 
-function rest (key, secret, nonceGenerator) {
+function rest (key, secret, opts = {}) {
   this.url = 'https://api.bitfinex.com'
   this.version = 'v1'
   this.key = key
   this.secret = secret
-  this.nonce = new Date().getTime()
-  this._nonce = typeof nonceGenerator === 'function' ? nonceGenerator : function () {
+  this.nonce = Date.now()
+  this.generateNonce = (typeof opts.nonceGenerator === 'function')
+      ? opts.nonceGenerator
+      : function () {
         // noinspection JSPotentiallyInvalidUsageOfThis
-    return ++this.nonce
-  }
+        return ++this.nonce
+      }
 }
 
 rest.prototype.make_request = function (path, params, cb) {
@@ -23,7 +25,7 @@ rest.prototype.make_request = function (path, params, cb) {
     return cb(new Error('missing api key or secret'))
   }
   url = `${this.url}/${this.version}/${path}`
-  nonce = JSON.stringify(this._nonce())
+  nonce = JSON.stringify(this.generateNonce())
   payload = {
     request: `/${this.version}/${path}`,
     nonce

--- a/rest.js
+++ b/rest.js
@@ -257,6 +257,10 @@ rest.prototype.active_orders = function (cb) {
   return this.make_request('orders', {}, cb)
 }
 
+rest.prototype.orders_history = function (cb) {
+  return this.make_request('orders/hist', {}, cb)
+}
+
 rest.prototype.active_positions = function (cb) {
   return this.make_request('positions', {}, cb)
 }

--- a/rest2.js
+++ b/rest2.js
@@ -115,6 +115,10 @@ class Rest2 {
     return this.makeAuthRequest(`/auth/w/alert/set`, {symbol, price})
   }
 
+  trades (symbol = 'tBTCUSD', start = null, end = null, limit = null, cb) {
+    return this.makeAuthRequest(`/auth/r/trades/${symbol}/hist`, {start, end, limit}, cb)
+  }
+
   // TODO
   // - Wallets
   // - Orders


### PR DESCRIPTION
I noticed that v1 rest() had a nonceGenerator param, but that index.js never gives the option to utilize your own nonceGenerator. So I figured I'd update the v1 implementation the same way v2 is implemented, which seems a bit clearer anyway.

As for v2 /trades, I just needed to hit that endpoint and it hadn't been implemented yet.