### PR TITLE
Wrong endpoint for candles

### DIFF
--- a/rest2.js
+++ b/rest2.js
@@ -115,7 +115,7 @@ class Rest2 {
   // note: query params can be added: see
   // http://docs.bitfinex.com/v2/reference#rest-public-candles
   candles ({timeframe = '1m', symbol = 'tBTCUSD', section = 'hist'}, cb) {
-    return this.makePublicRequest(`stats1/trade:${timeframe}:${symbol}/${section}`, cb)
+    return this.makePublicRequest(`candles/trade:${timeframe}:${symbol}/${section}`, cb)
   }
 
   // Auth endpoints


### PR DESCRIPTION
As per the docs, it is `candles` not `stats1` Simple copy/paste error.