### PR TITLE
when an error occurs also return the statusMessage (if exists)

### DIFF
--- a/rest.js
+++ b/rest.js
@@ -47,7 +47,7 @@ rest.prototype.make_request = function (path, params, cb) {
   }, (err, response, body) => {
     let error, result
     if (err || (response.statusCode !== 200 && response.statusCode !== 400)) {
-      return cb(new Error(err != null ? err : response.statusCode))
+      return cb(new Error(err != null ? err : response.statusCode + (response.statusMessage && ' ' +  response.statusMessage)))
     }
     try {
       result = JSON.parse(body)
@@ -78,7 +78,7 @@ rest.prototype.make_public_request = function (path, cb) {
   }, (err, response, body) => {
     let error, result
     if (err || (response.statusCode !== 200 && response.statusCode !== 400)) {
-      return cb(new Error(err != null ? err : response.statusCode))
+      return cb(new Error(err != null ? err : response.statusCode + (response.statusMessage && ' ' +  response.statusMessage)))
     }
     try {
       result = JSON.parse(body)


### PR DESCRIPTION
When REST API (v1) returns and error and `statusMessage` exists, add it to the error message.

The code be tested by sending a large number API calls in order to 'force' return of error 429 "Too Many Requests"