### PR TITLE
Fix: nonce is too small

### DIFF
--- a/rest.js
+++ b/rest.js
@@ -8,7 +8,7 @@ function rest (key, secret, opts = {}) {
   this.version = 'v1'
   this.key = key
   this.secret = secret
-  this.nonce = Date.now()
+  this.nonce = Date.now() * 1000
   this.generateNonce = (typeof opts.nonceGenerator === 'function')
       ? opts.nonceGenerator
       : function () {

--- a/rest2.js
+++ b/rest2.js
@@ -10,7 +10,7 @@ class Rest2 {
     this.version = 'v2'
     this.key = key
     this.secret = secret
-    this.nonce = Date.now()
+    this.nonce = Date.now() * 1000
     this.generateNonce = (typeof opts.nonceGenerator === 'function')
       ? opts.nonceGenerator
       : function () {


### PR DESCRIPTION
It was impossible to use the API as one of the last bitfinex API update without this simple line
 `this.nonce = Date.now() * 1000`

Looks like it resolves the issue permanently

Fix #108, fix #111, fix #116 
