### PR TITLE
(fix) Translate symbol names to v2 standard

### DIFF
--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -436,7 +436,12 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v1/reference#rest-public-symbols
    */
   symbols (cb) {
-    return this._rest1.make_public_request('symbols', cb)
+    return this._rest1.make_public_request('symbols', (err, symbols) => {
+      if (err) {
+        return cb(err)
+      }
+      return cb(null, symbols.map(symbol => 't' + symbol.toUpperCase()))
+    })
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -274,6 +274,8 @@ class WSv2 extends EventEmitter {
     this._lastAuthSeq = -1
     this._lastPubSeq = -1
     this._ws = null
+    this._subscriptionRefs = {}
+    this._channelMap = {}
     this.emit('close')
 
     debug('connection closed')


### PR DESCRIPTION
The `rest2.symbols` call relies on the deprecated rest1 version. Symbol names returned by v1 API differ from those used in v2. This can cause subtle errors because v2 allows to subscribe with v1 symbol names but it fails to unsubscribe them unless you use the v2 symbol names. Code below reproduces this error:

```javascript
const BFX = require('bitfinex-api-node');

const bfx = new BFX();

const rest = bfx.rest(2);
rest.symbols((err, symbols) => {
  if (err) {
    return console.log(err);
  }

  const ws = bfx.ws(2);
  ws.on('open', () => {
    console.log('Subscribing to: ', symbols);
    symbols.forEach(symbol => ws.subscribeTrades(symbol));

    ws.on('trades', (symbol, trades) => {
      console.log(symbol, trades);
    });
  });
  ws.open();

  setTimeout( () => {
    console.log('Unsubscribe');
    symbols.forEach(symbol => ws.unsubscribeTrades(symbol));
  }, 5000);
});
```

If you run this code it won't unsubscribe because symbol names used for subscription don't work for unsubscription.

I have not found a *v2 native* way of getting the list of symbols but the deprecated version relies on v1 call. So, as a workaround, we could just translate v1 symbols to v2 names.


