### PR TITLE
(fix) Clean up subscriptors on closed connection

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -274,6 +274,8 @@ class WSv2 extends EventEmitter {
     this._lastAuthSeq = -1
     this._lastPubSeq = -1
     this._ws = null
+    this._subscriptionRefs = {}
+    this._channelMap = {}
     this.emit('close')
 
     debug('connection closed')


### PR DESCRIPTION
If we do not clean up the subscription refs on close we cannot subscribe again to previous subscribed symbols. So when you try to subscribe again those symbols are skipped because they are already present in `this._subscriptionRefs`.

If you try the code below you will receive data up to the first close. From then on no more data is received.

```javascript
const BFX = require('bitfinex-api-node');

const bfx = new BFX({
  ws: {
    autoReconnect: true,
  }
});

const ws = bfx.ws(2);
ws.on('open', () => {
  ws.subscribeTrades('tBTCUSD');

  ws.on('trades', (symbol, trades) => {
    console.log(symbol, trades);
  });
});

ws.on('close', () => {
  console.log('Connection closed!');
});
ws.open();

setInterval( () => {
  // Simulate a socket close
  ws._ws.close();
}, 5000);
```

