### PR TITLE
Improve Transport APIs

### DIFF
--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const rp = require('request-promise')
+const { URLSearchParams } = require('url')
 
 const RESTv1 = require('./rest')
 const { genAuthSig, nonce } = require('../util')
@@ -21,17 +22,6 @@ const {
 
 const BASE_TIMEOUT = 15000
 const API_URL = 'https://api.bitfinex.com'
-
-// TODO: Extract into util/use in RESTv1?
-const integrateQuery = (url, query) => {
-  const params = Object.keys(query)
-
-  if (params.length > 0) {
-    return `${url}?${params.map(p => `${p}=${query[p]}`).join('&')}`
-  }
-
-  return url
-}
 
 /**
  * Communicates with v2 of the Bitfinex HTTP API
@@ -252,11 +242,13 @@ class RESTv2 {
     section = 'hist',
     query = {}
   }, cb) {
-    const path = integrateQuery(
-      `/candles/trade:${timeframe}:${symbol}/${section}`, query
-    )
+    let url = `/candles/trade:${timeframe}:${symbol}/${section}`
 
-    return this._makePublicRequest(path, cb, Candle)
+    if (Object.keys(query).length > 0) {
+      url += `?${new URLSearchParams(query).toString()}`
+    }
+
+    return this._makePublicRequest(url, cb, Candle)
   }
 
   /**

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -15,11 +15,23 @@ const {
   Trade,
   Wallet,
   Alert,
-  Ticker
+  Ticker,
+  Candle
 } = require('../models')
 
 const BASE_TIMEOUT = 15000
 const API_URL = 'https://api.bitfinex.com'
+
+// TODO: Extract into util/use in RESTv1?
+const integrateQuery = (url, query) => {
+  const params = Object.keys(query)
+
+  if (params.length > 0) {
+    return `${url}?${params.map(p => `${p}=${query[p]}`).join('&')}`
+  }
+
+  return url
+}
 
 /**
  * Communicates with v2 of the Bitfinex HTTP API
@@ -234,8 +246,17 @@ class RESTv2 {
    * @return {Promise} p
    * @see http://docs.bitfinex.com/v2/reference#rest-public-candles
    */
-  candles ({ timeframe = '1m', symbol = 'tBTCUSD', section = 'hist' }, cb) {
-    return this._makePublicRequest(`/candles/trade:${timeframe}:${symbol}/${section}`, cb)
+  candles ({
+    timeframe = '1m',
+    symbol = 'tBTCUSD',
+    section = 'hist',
+    query = {}
+  }, cb) {
+    const path = integrateQuery(
+      `/candles/trade:${timeframe}:${symbol}/${section}`, query
+    )
+
+    return this._makePublicRequest(path, cb, Candle)
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -481,7 +481,6 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _updateManagedOB (symbol, data) {
-
     // Snapshot, new OB. Note that we don't protect against duplicates, as they
     // could come in on re-sub
     if (Array.isArray(data[0])) {
@@ -1408,51 +1407,77 @@ class WSv2 extends EventEmitter {
   /**
    * @param {Object} opts
    * @param {string} opts.symbol
+   * @param {number} opts.id
+   * @param {number} opts.cid
    * @param {number} opts.gid
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-orders
    */
-  onOrderSnapshot ({ symbol, gid, cbGID }, cb) {
-    this._registerListener('os', { 3: symbol, 1: gid }, Order, cbGID, cb)
+  onOrderSnapshot ({ symbol, id, cid, gid, cbGID }, cb) {
+    this._registerListener('os', {
+      0: id,
+      1: gid,
+      2: cid,
+      3: symbol
+    }, Order, cbGID, cb)
   }
 
   /**
    * @param {Object} opts
-   * @param {string} opts.symbol
-   * @param {number} opts.gid
-   * @param {string} opts.cbGID - callback group id
+   * @param {string?} opts.symbol
+   * @param {number?} opts.id
+   * @param {number?} opts.cid
+   * @param {number?} opts.gid
+   * @param {string?} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-orders
    */
-  onOrderNew ({ symbol, gid, cbGID }, cb) {
-    this._registerListener('on', { 3: symbol, 1: gid }, Order, cbGID, cb)
+  onOrderNew ({ symbol, id, cid, gid, cbGID }, cb) {
+    this._registerListener('on', {
+      0: id,
+      1: gid,
+      2: cid,
+      3: symbol
+    }, Order, cbGID, cb)
   }
 
   /**
    * @param {Object} opts
    * @param {string} opts.symbol
+   * @param {number} opts.id
    * @param {number} opts.gid
    * @param {number} opts.cid
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-orders
    */
-  onOrderUpdate ({ symbol, gid, cid, cbGID }, cb) {
-    this._registerListener('ou', { 3: symbol, 1: gid, 2: cid }, Order, cbGID, cb)
+  onOrderUpdate ({ symbol, id, cid, gid, cbGID }, cb) {
+    this._registerListener('ou', {
+      0: id,
+      1: gid,
+      2: cid,
+      3: symbol
+    }, Order, cbGID, cb)
   }
 
   /**
    * @param {Object} opts
    * @param {string} opts.symbol
+   * @param {number} opts.id
    * @param {number} opts.gid
    * @param {number} opts.cid
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-orders
    */
-  onOrderClose ({ symbol, gid, cid, cbGID }, cb) {
-    this._registerListener('oc', { 3: symbol, 1: gid, 2: cid }, Order, cbGID, cb)
+  onOrderClose ({ symbol, id, cid, gid, cbGID }, cb) {
+    this._registerListener('oc', {
+      0: id,
+      1: gid,
+      2: cid,
+      3: symbol
+    }, Order, cbGID, cb)
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -481,11 +481,10 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _updateManagedOB (symbol, data) {
-    if (Array.isArray(data[0])) { // snapshot, new OB
-      if (this._orderBooks[symbol]) {
-        return new Error(`recv snapshot for known OB: ${symbol}`)
-      }
 
+    // Snapshot, new OB. Note that we don't protect against duplicates, as they
+    // could come in on re-sub
+    if (Array.isArray(data[0])) {
       this._orderBooks[symbol] = data
       return null
     }
@@ -606,10 +605,6 @@ class WSv2 extends EventEmitter {
    */
   _updateManagedCandles (key, data) {
     if (Array.isArray(data[0])) { // snapshot, new candles
-      if (this._candles[key]) {
-        return new Error(`recv snapshot for known candles: ${key}`)
-      }
-
       data.sort((a, b) => b[0] - a[0])
 
       this._candles[key] = data

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -794,16 +794,6 @@ describe('WSv2 channel msg handling', () => {
     assert(err instanceof Error)
   })
 
-  it('_updateManagedOB: returns error if update is snap & ob exists', () => {
-    const ws = new WSv2()
-    const errA = ws._updateManagedOB('tBTCUSD', [[150, 0, -1]])
-    const errB = ws._updateManagedOB('tBTCUSD', [[150, 0, -1]])
-
-    assert(!errA)
-    assert(errB)
-    assert(errB instanceof Error)
-  })
-
   it('_updateManagedOB: correctly maintains transformed OBs', () => {
     const ws = new WSv2({ transform: true })
     ws._orderBooks.tBTCUSD = []
@@ -890,17 +880,9 @@ describe('WSv2 channel msg handling', () => {
     let errorsSeen = 0
 
     ws.on('error', () => {
-      if (++errorsSeen === 2) done()
+      if (++errorsSeen === 1) done()
     })
 
-    ws._handleCandleMessage([64, [
-      [5, 100, 70, 150, 30, 1000],
-      [2, 200, 90, 150, 30, 1000],
-      [1, 130, 90, 150, 30, 1000],
-      [4, 104, 80, 150, 30, 1000]
-    ]], ws._channelMap[64])
-
-    // duplicate snapshot
     ws._handleCandleMessage([64, [
       [5, 100, 70, 150, 30, 1000],
       [2, 200, 90, 150, 30, 1000],
@@ -993,21 +975,6 @@ describe('WSv2 channel msg handling', () => {
 
     const err = ws._updateManagedCandles('trade:30m:tBTCUSD', [
       1, 10, 70, 150, 30, 10
-    ])
-
-    assert(err)
-    assert(err instanceof Error)
-  })
-
-  it('_updateManagedCandles: returns error if update is snap & candles exist', () => {
-    const ws = new WSv2()
-    ws._candles['trade:1m:tBTCUSD'] = [
-      [1, 10, 70, 150, 30, 10],
-      [2, 10, 70, 150, 30, 10]
-    ]
-
-    const err = ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      [1, 10, 70, 150, 30, 10]
     ])
 
     assert(err)


### PR DESCRIPTION
 * add query args field to REST2 `candles()` query
 * allow duplicate candle/OB snapshots
 * allow filtering `o*` event packets by all IDs & symbol