### PR TITLE
Fix candle subscription on reconnect

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -128,6 +128,8 @@ class WSv2 extends EventEmitter {
     this._ws = new WebSocket(this._url, {
       agent: this._agent
     })
+    this._subscriptionRefs = {}
+    this._candles = {}
 
     if (this._seqAudit) {
       this._ws.once('open', this.enableSequencing.bind(this))

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -130,6 +130,7 @@ class WSv2 extends EventEmitter {
     })
     this._subscriptionRefs = {}
     this._candles = {}
+    this._orderBooks = {}
 
     if (this._seqAudit) {
       this._ws.once('open', this.enableSequencing.bind(this))


### PR DESCRIPTION
Mentioned in [#233](https://github.com/bitfinexcom/bitfinex-api-node/issues/233), candles are not resubscribing after reconnect because the subscriptionRefs object is not getting cleared. This fixes the issue so candle subscriptions resume assuming the user resubscribes on ws open.