### PR TITLE
Feature: OB Checksum Support & Validation

### DIFF
--- a/examples/ws2/ob_checksum.js
+++ b/examples/ws2/ob_checksum.js
@@ -1,32 +1,37 @@
 'use strict'
 
-// process.env.DEBUG = 'bfx:examples:*'
-process.env.DEBUG = '*'
+process.env.DEBUG = 'bfx:examples:*'
 
 const debug = require('debug')('bfx:examples:ws2_ob_checksum')
 const bfx = require('../bfx')
 const WSv2 = require('../../lib/transports/ws2')
 
 const SYMBOL = 'tBTCUSD'
+const PRECISION = 'R0'
+const LENGTH = '100'
 
 const ws = bfx.ws(2, {
-  manageOrderBooks: true,
-  transform: true
+  manageOrderBooks: true // managed OBs are verified against incoming checksums
 })
 
-ws.on('error', (err) => {
-  console.error(err)
+// catch checksum mis-matches
+ws.on('error', err => {
+  debug('error %s:%s:%s %s', SYMBOL, PRECISION, LENGTH, err.message)
 })
 
 ws.on('open', () => {
   debug('open')
 
   ws.enableFlag(WSv2.flags.CHECKSUM)
-  ws.subscribeOrderBook(SYMBOL, 'R0', '100')
+  ws.subscribeOrderBook(SYMBOL, PRECISION, LENGTH)
 })
 
-ws.onOrderBookChecksum({ symbol: SYMBOL, prec: 'R0', len: '100' }, cs => {
-  debug('recv cs for %s:R0:100 - %d', SYMBOL, cs)
+ws.onOrderBookChecksum({
+  symbol: SYMBOL,
+  prec: PRECISION,
+  len: LENGTH
+}, cs => {
+  debug('recv valid cs for %s:%s:%s %d', SYMBOL, PRECISION, LENGTH, cs)
 })
 
 ws.open()

--- a/examples/ws2/ob_checksum.js
+++ b/examples/ws2/ob_checksum.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// process.env.DEBUG = 'bfx:examples:*'
+process.env.DEBUG = '*'
+
+const debug = require('debug')('bfx:examples:ws2_ob_checksum')
+const bfx = require('../bfx')
+const WSv2 = require('../../lib/transports/ws2')
+
+const SYMBOL = 'tBTCUSD'
+
+const ws = bfx.ws(2, {
+  manageOrderBooks: true,
+  transform: true
+})
+
+ws.on('error', (err) => {
+  console.error(err)
+})
+
+ws.on('open', () => {
+  debug('open')
+
+  ws.enableFlag(WSv2.flags.CHECKSUM)
+  ws.subscribeOrderBook(SYMBOL, 'R0', '100')
+})
+
+ws.onOrderBookChecksum({ symbol: SYMBOL, prec: 'R0', len: '100' }, cs => {
+  debug('recv cs for %s:R0:100 - %d', SYMBOL, cs)
+})
+
+ws.open()

--- a/lib/models/order_book.js
+++ b/lib/models/order_book.js
@@ -295,7 +295,9 @@ class OrderBook extends EventEmitter {
     let insertIndex = -1
 
     for (let i = 0; i < ob.length; i++) {
-      if (price > ob[i][priceI] && insertIndex === -1) insertIndex = i
+      if (price > ob[i][priceI] && insertIndex === -1) {
+        insertIndex = i
+      }
 
       if ((!raw && ob[i][priceI] === price) || (raw && ob[i][0] === entry[0])) {
         if ((!raw && count === 0) || (raw && price === 0)) {

--- a/lib/models/order_book.js
+++ b/lib/models/order_book.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const debug = require('debug')('bitfinex:ws:orderbook')
+const CRC = require('crc-32')
+
+const { preparePrice } = require('../util/precision')
 
 /**
  * High level OB model to automatically integrate WS updates & maintain sort
@@ -9,17 +13,103 @@ class OrderBook extends EventEmitter {
   /**
    * Initializes the order book with an existing snapshot (array form)
    *
-   * @param {Array[]} snapshot
+   * @param {Array[]|OrderBook} snapshot
+   * @param {boolean?} raw - true for raw 'R0' order books
    */
-  constructor (snapshot = []) {
+  constructor (snap = [], raw = false) {
     super()
 
-    if (snapshot && snapshot.length > 0) {
-      this.updateFromSnapshot(snapshot)
+    this.raw = raw
+
+    if (snap instanceof OrderBook) {
+      this.bids = snap.bids.slice()
+      this.asks = snap.asks.slice()
+    } else if (snap && Array.isArray(snap)) {
+      this.updateFromSnapshot(snap)
+    } else if (snap && Array.isArray(snap.bids) && Array.isArray(snap.asks)) {
+      this.bids = snap.bids.slice()
+      this.asks = snap.asks.slice()
     } else {
       this.bids = []
       this.asks = []
     }
+  }
+
+  /**
+   * @return {number} cs
+   */
+  checksum () {
+    const { raw } = this
+    const data = []
+
+    for (let i = 0; i < 25; i += 1) {
+      const bid = this.bids[i]
+      const ask = this.asks[i]
+
+      if (bid) {
+        data.push(
+          raw ? bid[0] : Number(preparePrice(bid[0])),
+          bid[2]
+        )
+      }
+
+      if (ask) {
+        data.push(
+          raw ? ask[0] : Number(preparePrice(ask[0])),
+          ask[2]
+        )
+      }
+    }
+
+    return CRC.str(data.join(':'))
+  }
+
+  /**
+   * @param {Array[]} arr - assumed sorted, [topBid, bid, ..., topAsk, ask, ...]
+   * @param {boolean?} raw - true for raw 'R0' order books
+   * @return {number} cs
+   */
+  static checksumArr (arr, raw = false) {
+    let topAskI = -1
+
+    for (let i = 0; i < arr.length; i += 1) {
+      if (arr[i][2] < 0) {
+        topAskI = i
+        break
+      }
+    }
+
+    const data = []
+
+    let ask
+    let bid
+
+    // Either bids/asks may be empty, or have differing lengths
+    for (let i = 0; i < 25; i += 1) {
+      bid = topAskI === -1 || i < topAskI
+        ? arr[i]
+        : null
+
+      ask = topAskI === -1
+        ? null
+        : arr[topAskI + i]
+
+      if (bid) {
+        data.push(
+          raw ? bid[0] : Number(preparePrice(bid[0])),
+          bid[2]
+        )
+      }
+
+      if (ask) {
+        data.push(
+          raw ? ask[0] : Number(preparePrice(ask[0])),
+          ask[2]
+        )
+      }
+    }
+
+    return CRC.str(data.join(':'))
   }
 
   updateFromSnapshot (snapshot) {
@@ -35,8 +125,10 @@ class OrderBook extends EventEmitter {
     }
 
     // snapshots may not be sorted
-    this.bids.sort((a, b) => b[0] - a[0])
-    this.asks.sort((a, b) => a[0] - b[0])
+    const priceI = this.raw ? 1 : 0
+
+    this.bids.sort((a, b) => b[priceI] - a[priceI])
+    this.asks.sort((a, b) => a[priceI] - b[priceI])
   }
 
   /**
@@ -46,23 +138,36 @@ class OrderBook extends EventEmitter {
    * @return {boolean} success - false if entry doesn't match OB
    */
   updateWith (entry) {
-    const [price, count, amount] = entry
+    const { raw } = this
+    const priceI = raw ? 1 : 0
+    const count = raw ? -1 : entry[1]
+    const price = entry[priceI]
+    const oID = entry[0] // only for raw books
+    const amount = entry[2]
     const side = amount < 0 ? this.asks : this.bids
+
     let insertIndex = -1
+
+    if (side.length === 0 && (raw || count > 0)) {
+      side.push(entry)
+      this.emit('update', entry)
+      return true
+    }
 
     for (let i = 0; i < side.length; i++) {
       if (insertIndex === -1 && (
-        (amount > 0 && price > side[i][0]) ||
-        (amount < 0 && price < side[i][0])
+        (amount > 0 && price > side[i][priceI]) ||
+        (amount < 0 && price < side[i][priceI])
       )) {
         insertIndex = i
       }
 
-      if (side[i][0] === price) {
-        if (count === 0) {        // remove
+      // Match by price level, or order ID for raw books
+      if ((!raw && side[i][priceI] === price) || (raw && side[i][0] === oID)) {
+        if ((!raw && count === 0) || (raw && price === 0)) { // remove
           side.splice(i, 1)
-        } else {
-          side[i] = entry         // update
+        } else if (!raw || (raw && price > 0)) {
+          side[i] = entry // update
         }
 
         this.emit('update', entry)
@@ -71,11 +176,8 @@ class OrderBook extends EventEmitter {
     }
 
     // remove unkown
-    if (count === 0) {
-      this.emit('error', new Error(
-        `can't remove unknown price level: ${JSON.stringify(entry)}`
-      ))
-
+    if ((raw && price === 0) || (!raw && count === 0)) {
+      debug(`ignoring unknown price level: ${JSON.stringify(entry)}`)
       return false
     }
 
@@ -94,14 +196,29 @@ class OrderBook extends EventEmitter {
    * @return {number} price
    */
   midPrice () {
-    return (this.asks[0][0] + this.bids[0][0]) / 2
+    const priceI = this.raw ? 1 : 0
+    const topAsk = (this.asks[0] || [])[priceI] || 0
+    const topBid = (this.bids[0] || [])[priceI] || 0
+
+    if (topAsk === 0) return topBid
+    if (topBid === 0) return topAsk
+
+    return (topAsk + topBid) / 2
   }
 
   /**
    * @return {number} spread - top bid/ask difference
    */
   spread () {
-    return this.asks[0][0] - this.bids[0][0]
+    const priceI = this.raw ? 1 : 0
+    const topAsk = (this.asks[0] || [])[priceI] || 0
+    const topBid = (this.bids[0] || [])[priceI] || 0
+
+    if (topAsk === 0 || topBid === 0) {
+      return 0
+    }
+
+    return topAsk - topBid
   }
 
   /**
@@ -135,12 +252,13 @@ class OrderBook extends EventEmitter {
    * @return {Object} entry - unserialized, null if not found
    */
   getEntry (price) {
-    const side = this.asks.length > 0 // pick a side w/ incomplete data
-      ? price >= this.asks[0][0] ? this.asks : this.bids
-      : price <= this.bids[0][0] ? this.bids : this.asks
+    const priceI = this.raw ? 1 : 0
+    const side = this.asks.length > 0
+      ? price >= this.asks[0][priceI] ? this.asks : this.bids
+      : price <= this.bids[0][priceI] ? this.bids : this.asks
 
     for (let i = 0; i < side.length; i++) {
-      if (price === side[i][0]) {
+      if (price === side[i][priceI]) {
         return OrderBook.unserialize(side[i])
       }
     }
@@ -158,20 +276,23 @@ class OrderBook extends EventEmitter {
    *
    * @param {number[][]} ob
    * @param {number[]} entry
+   * @param {boolean?} raw - true for raw 'R0' order books
    * @return {boolean} success - false if entry doesn't match OB
    */
-  static updateArrayOBWith (ob, entry) {
-    const [price, count] = entry
+  static updateArrayOBWith (ob, entry, raw = false) {
+    const priceI = raw ? 1 : 0
+    const price = entry[priceI]
+    const count = raw ? -1 : entry[1]
     let insertIndex = -1
 
     for (let i = 0; i < ob.length; i++) {
-      if (price > ob[i][0] && insertIndex === -1) insertIndex = i
+      if (price > ob[i][priceI] && insertIndex === -1) insertIndex = i
 
-      if (ob[i][0] === price) {
-        if (count === 0) {
+      if ((!raw && ob[i][priceI] === price) || (raw && ob[i][0] === entry[0])) {
+        if ((!raw && count === 0) || (raw && price === 0)) {
           ob.splice(i, 1) // remove existing
         } else {
-          ob[i] = entry   // update existing
+          ob[i] = entry // update existing
         }
 
         return true
@@ -179,7 +300,7 @@ class OrderBook extends EventEmitter {
     }
 
     // remove unkown
-    if (count === 0) return false
+    if ((!raw && count === 0) || (raw && price === 0)) return false
 
     // add
     if (insertIndex === -1) {
@@ -191,9 +312,10 @@ class OrderBook extends EventEmitter {
     return true
   }
 
-  static arrayOBMidPrice (ob = []) {
+  static arrayOBMidPrice (ob = [], raw = false) {
     if (ob.length === 0) return null
 
+    const priceI = raw ? 1 : 0
     let bestBuy = -Infinity
     let bestAsk = Infinity
     let entry
@@ -201,8 +323,8 @@ class OrderBook extends EventEmitter {
     for (let i = 0; i < ob.length; i++) {
       entry = ob[i]
 
-      if (entry[2] > 0 && entry[0] > bestBuy) bestBuy = entry[0]
-      if (entry[2] < 0 && entry[0] < bestAsk) bestAsk = entry[0]
+      if (entry[2] > 0 && entry[priceI] > bestBuy) bestBuy = entry[priceI]
+      if (entry[2] < 0 && entry[priceI] < bestAsk) bestAsk = entry[priceI]
     }
 
     if (bestBuy === -Infinity || bestAsk === Infinity) return null
@@ -215,9 +337,10 @@ class OrderBook extends EventEmitter {
    * 'count', and 'amount' keys on entries
    *
    * @param {number[]|number[][]} arr
+   * @param {boolean?} raw - true for raw 'R0' order books
    * @return {Object} ob - either a map w/ bids & asks, or single entry object
    */
-  static unserialize (arr) {
+  static unserialize (arr, raw = false) {
     if (Array.isArray(arr[0])) {
       const entries = arr.map(e => OrderBook.unserialize(e))
       const bids = entries.filter(e => e.amount > 0)
@@ -226,7 +349,11 @@ class OrderBook extends EventEmitter {
       return { bids, asks }
     }
 
-    return {
+    return raw ? {
+      orderID: arr[0],
+      price: arr[1],
+      amount: arr[2]
+    } : {
       price: arr[0],
       count: arr[1],
       amount: arr[2]

--- a/lib/models/order_book.js
+++ b/lib/models/order_book.js
@@ -36,6 +36,10 @@ class OrderBook extends EventEmitter {
   }
 
   /**
+   * Generates a crc-32 checksum of our current state. The checksum'ed string
+   * itself is a concatenated list of the top 25 bids & asks, alternating.
+   * @see http://blog.bitfinex.com/api/bitfinex-api-order-books-checksums
+   *
    * @return {number} cs
    */
   checksum () {
@@ -48,15 +52,15 @@ class OrderBook extends EventEmitter {
 
       if (bid) {
         data.push(
-          raw ? bid[0] : Number(preparePrice(bid[0])),
-          bid[2]
+          raw ? bid[0] : Number(preparePrice(bid[0])), // order ID or price
+          bid[2] // amount
         )
       }
 
       if (ask) {
         data.push(
-          raw ? ask[0] : Number(preparePrice(ask[0])),
-          ask[2]
+          raw ? ask[0] : Number(preparePrice(ask[0])), //
+          ask[2] //
         )
       }
     }
@@ -65,6 +69,8 @@ class OrderBook extends EventEmitter {
   }
 
   /**
+   * Like checksum(), but for raw array-format order books
+   *
    * @param {Array[]} arr - assumed sorted, [topBid, bid, ..., topAsk, ask, ...]
    * @param {boolean?} raw - true for raw 'R0' order books
    * @return {number} cs
@@ -72,6 +78,7 @@ class OrderBook extends EventEmitter {
   static checksumArr (arr, raw = false) {
     let topAskI = -1
 
+    // find first ask (book is sorted bids first)
     for (let i = 0; i < arr.length; i += 1) {
       if (arr[i][2] < 0) {
         topAskI = i
@@ -86,9 +93,9 @@ class OrderBook extends EventEmitter {
 
     // Either bids/asks may be empty, or have differing lengths
     for (let i = 0; i < 25; i += 1) {
-      bid = topAskI === -1 || i < topAskI
+      bid = topAskI === -1 || i < topAskI // still reading bids
         ? arr[i]
-        : null
+        : null // reached asks
 
       ask = topAskI === -1
         ? null
@@ -96,15 +103,15 @@ class OrderBook extends EventEmitter {
 
       if (bid) {
         data.push(
-          raw ? bid[0] : Number(preparePrice(bid[0])),
-          bid[2]
+          raw ? bid[0] : Number(preparePrice(bid[0])), // order ID or price
+          bid[2] // amount
         )
       }
 
       if (ask) {
         data.push(
-          raw ? ask[0] : Number(preparePrice(ask[0])),
-          ask[2]
+          raw ? ask[0] : Number(preparePrice(ask[0])), //
+          ask[2] //
         )
       }
     }
@@ -132,7 +139,8 @@ class OrderBook extends EventEmitter {
   }
 
   /**
-   * Integrate an update packet; emits an 'update' event on success
+   * Integrate an update packet (add, update, or remove a price level). Emits an
+   * 'update' event on success
    *
    * @param {Array} entry
    * @return {boolean} success - false if entry doesn't match OB
@@ -148,6 +156,7 @@ class OrderBook extends EventEmitter {
 
     let insertIndex = -1
 
+    // apply insert directly if empty
     if (side.length === 0 && (raw || count > 0)) {
       side.push(entry)
       this.emit('update', entry)
@@ -159,13 +168,13 @@ class OrderBook extends EventEmitter {
         (amount > 0 && price > side[i][priceI]) ||
         (amount < 0 && price < side[i][priceI])
       )) {
-        insertIndex = i
+        insertIndex = i // insert index to maintain sort
       }
 
       // Match by price level, or order ID for raw books
       if ((!raw && side[i][priceI] === price) || (raw && side[i][0] === oID)) {
-        if ((!raw && count === 0) || (raw && price === 0)) { // remove
-          side.splice(i, 1)
+        if ((!raw && count === 0) || (raw && price === 0)) {
+          side.splice(i, 1) // remove
         } else if (!raw || (raw && price > 0)) {
           side[i] = entry // update
         }

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -512,7 +512,7 @@ class WSv2 extends EventEmitter {
       chanData.len
     ]
 
-    this._propagateMessageToListeners(internalMessage, chanData, false)
+    this._propagateMessageToListeners(internalMessage, false)
     this.emit('cs', symbol, cs)
   }
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -455,7 +455,7 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleChannelMessage (msg) {
-    const [chanId] = msg
+    const [chanId, type] = msg
     const channelData = this._channelMap[chanId]
 
     if (!channelData) {
@@ -469,6 +469,10 @@ class WSv2 extends EventEmitter {
     if (msg[1] === 'hb') return // TODO: optionally track seq
 
     if (channelData.channel === 'book') {
+      if (type === 'cs') {
+        return this._handleOBChecksumMessage(msg, channelData)
+      }
+
       return this._handleOBMessage(msg, channelData)
     } else if (channelData.channel === 'trades') {
       return this._handleTradeMessage(msg, channelData)
@@ -484,6 +488,34 @@ class WSv2 extends EventEmitter {
     }
   }
 
+  _handleOBChecksumMessage (msg, chanData) {
+    this.emit('cs', msg)
+
+    if (!this._manageOrderBooks) {
+      return
+    }
+
+    const { symbol, prec } = chanData
+    const cs = msg[2]
+
+    const err = this._verifyManagedOBChecksum(symbol, prec, cs)
+
+    if (err) {
+      this.emit('error', err)
+      return
+    }
+
+    const internalMessage = [chanData.chanId, 'ob_checksum', cs]
+    internalMessage.filterOverride = [
+      chanData.symbol,
+      chanData.prec,
+      chanData.len
+    ]
+
+    this._propagateMessageToListeners(internalMessage, chanData, false)
+    this.emit('cs', symbol, cs)
+  }
+
   /**
    * Called for messages from the 'book' channel. Might be an update or a
    * snapshot
@@ -493,11 +525,12 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleOBMessage (msg, chanData) {
-    const { symbol } = chanData
+    const { symbol, prec } = chanData
+    const raw = prec === 'R0'
     let data = getMessagePayload(msg)
 
     if (this._manageOrderBooks) {
-      const err = this._updateManagedOB(symbol, data)
+      const err = this._updateManagedOB(symbol, data, raw)
 
       if (err) {
         this.emit('error', err)
@@ -505,12 +538,11 @@ class WSv2 extends EventEmitter {
       }
 
       data = this._orderBooks[symbol]
-    } else if (data.length > 0 && !Array.isArray(data[0])) {
-      data = [data] // always pass on an array of entries
     }
 
+    // Always transform an array of entries
     if (this._transform) {
-      data = new OrderBook(data)
+      data = new OrderBook((Array.isArray(data[0]) ? data : [data]), raw)
     }
 
     const internalMessage = [chanData.chanId, 'orderbook', data]
@@ -527,10 +559,11 @@ class WSv2 extends EventEmitter {
   /**
    * @param {string} symbol
    * @param {number[]|number[][]} data
+   * @param {boolean} raw
    * @return {Error} err - null on success
    * @private
    */
-  _updateManagedOB (symbol, data) {
+  _updateManagedOB (symbol, data, raw) {
     // Snapshot, new OB. Note that we don't protect against duplicates, as they
     // could come in on re-sub
     if (Array.isArray(data[0])) {
@@ -543,7 +576,9 @@ class WSv2 extends EventEmitter {
       return new Error(`recv update for unknown OB: ${symbol}`)
     }
 
-    const success = OrderBook.updateArrayOBWith(this._orderBooks[symbol], data)
+    const success = OrderBook.updateArrayOBWith(
+      this._orderBooks[symbol], data, raw
+    )
 
     if (!success) {
       return new Error(
@@ -552,6 +587,26 @@ class WSv2 extends EventEmitter {
     }
 
     return null
+  }
+
+  /**
+   * @param {string} symbol
+   * @param {string} prec - precision
+   * @param {number} cs - expected checksum
+   * @return {Error} err - null if none
+   */
+  _verifyManagedOBChecksum (symbol, prec, cs) {
+    const ob = this._orderBooks[symbol]
+
+    if (!ob) return null
+
+    const localCS = ob instanceof OrderBook
+      ? ob.checksum()
+      : OrderBook.checksumArr(ob, prec === 'R0')
+
+    return localCS !== cs
+      ? new Error(`OB checksum mismatch: got ${localCS}, want ${cs}`)
+      : null
   }
 
   /**
@@ -1480,6 +1535,23 @@ class WSv2 extends EventEmitter {
       1: prec,
       2: len
     }, OrderBook, cbGID, cb)
+  }
+
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.prec
+   * @param {string} opts.len
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-order-books
+   */
+  onOrderBookChecksum ({ symbol, prec, len, cbGID }, cb) {
+    this._registerListener('ob_checksum', {
+      0: symbol,
+      1: prec,
+      2: len
+    }, null, cbGID, cb)
   }
 
   /**

--- a/lib/util/precision.js
+++ b/lib/util/precision.js
@@ -1,0 +1,47 @@
+const Big = require('bignumber.js')
+
+const DEFAULT_SIG_FIGS = 5
+const PRICE_SIG_FIGS = 5
+const AMOUNT_DECIMALS = 8
+
+/**
+ * Smartly set the precision (decimal) on a value based off of the significant
+ * digit maximum. For example, calling with 3.34 when the max sig figs allowed
+ * is 5 would return '3.3400', the representation number of decimals IF they
+ * weren't zeros.
+ *
+ * @param {number} n
+ * @param {number} maxSigs - default 5
+ * @return {string} str
+ */
+const setSigFig = (number = 0, maxSigs = DEFAULT_SIG_FIGS) => {
+  const n = +(number)
+  if (!isFinite(n)) {
+    return number
+  }
+  const value = n.toPrecision(maxSigs)
+
+  return value.match(/e/)
+    ? new Big(value).toString()
+    : value
+}
+
+const setPrecision = (number = 0, decimals = 0) => {
+  const n = +(number)
+
+  return (isFinite(n))
+    ? n.toFixed(decimals)
+    : number
+}
+
+const prepareAmount = (amount = 0) => {
+  return setPrecision(amount, AMOUNT_DECIMALS)
+}
+
+const preparePrice = (price = 0) => {
+  return setSigFig(price, PRICE_SIG_FIGS)
+}
+
+module.exports = {
+  setSigFig, setPrecision, prepareAmount, preparePrice
+}

--- a/lib/util/precision.js
+++ b/lib/util/precision.js
@@ -21,7 +21,7 @@ const setSigFig = (number = 0, maxSigs = DEFAULT_SIG_FIGS) => {
   }
   const value = n.toPrecision(maxSigs)
 
-  return value.match(/e/)
+  return /e/.test(value)
     ? new Big(value).toString()
     : value
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "standard": "^10.0.2"
   },
   "dependencies": {
+    "bignumber.js": "^6.0.0",
     "cbq": "0.0.1",
+    "crc-32": "^1.2.0",
     "debug": "^2.2.0",
     "lodash": "^4.17.4",
     "lodash.throttle": "^4.1.1",

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const assert = require('assert')
+const CRC = require('crc-32')
 const { OrderBook } = require('../../../lib/models')
 
 describe('OrderBook model', () => {
@@ -15,6 +16,52 @@ describe('OrderBook model', () => {
 
     assert.deepEqual(ob.bids, [entries[0]])
     assert.deepEqual(ob.asks, [entries[1]])
+  })
+
+  it('checksum: returns expected value for normal OB', () => {
+    const ob = new OrderBook({
+      bids: [[6000, 1, 1], [5900, 1, 2]],
+      asks: [[6100, 1, -3], [6200, 1, -4]]
+    })
+
+    assert.equal(ob.checksum(), CRC.str('6000:1:6100:-3:5900:2:6200:-4'))
+  })
+
+  it('checksum: returns expected value for raw OB', () => {
+    const ob = new OrderBook({
+      bids: [[100, 6000, 1], [101, 6000, 2]], // first field is order ID here
+      asks: [[102, 6100, -3], [103, 6100, -4]]
+    }, true)
+
+    assert.equal(ob.checksum(), CRC.str('100:1:102:-3:101:2:103:-4'))
+  })
+
+  it('checksumArr: returns expected value for normal OB', () => {
+    const ob = [
+      [6000, 1, 1],
+      [5900, 1, 2],
+      [6100, 1, -3],
+      [6200, 1, -4]
+    ]
+
+    assert.equal(
+      OrderBook.checksumArr(ob),
+      CRC.str('6000:1:6100:-3:5900:2:6200:-4')
+    )
+  })
+
+  it('checksumArr: returns expected value for raw OB', () => {
+    const ob = [
+      [100, 6000, 1],
+      [101, 6000, 2],
+      [102, 6100, -3],
+      [103, 6100, -4]
+    ]
+
+    assert.equal(
+      OrderBook.checksumArr(ob, true),
+      CRC.str('100:1:102:-3:101:2:103:-4')
+    )
   })
 
   it('updateWith: correctly applies update', () => {

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -17,22 +17,6 @@ describe('OrderBook model', () => {
     assert.deepEqual(ob.asks, [entries[1]])
   })
 
-  it('updateWith: emits an error if removing an unknown price level', (done) => {
-    const entries = [
-      [100, 2, 10],
-      [200, 2, -10]
-    ]
-
-    const ob = new OrderBook(entries)
-
-    ob.on('error', (err) => {
-      assert(err.message.indexOf('unknown price') !== -1)
-      done()
-    })
-
-    ob.updateWith([300, 0, 1])
-  })
-
   it('updateWith: correctly applies update', () => {
     const entries = [
       [100, 2, 10],

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -71,29 +71,253 @@ describe('OrderBook model', () => {
     ]
 
     const ob = new OrderBook(entries)
-    ob.updateWith([100, 3, 15])
+    assert(ob.updateWith([100, 3, 15])) // update bid
+    assert(ob.updateWith([200, 3, -15])) // update ask
 
-    assert.deepEqual(ob.bids[0], [100, 3, 15])
-    assert.equal(ob.bids.length, 1)
+    assert.deepEqual(ob.bids, [[100, 3, 15]])
+    assert.deepEqual(ob.asks, [[200, 3, -15]])
 
-    ob.updateWith([100, 0, 1])
+    assert(ob.updateWith([100, 0, 15])) // remove bid
+    assert(ob.updateWith([200, 0, -15])) // remove ask
+
     assert.equal(ob.bids.length, 0)
+    assert.equal(ob.asks.length, 0)
+
+    assert(ob.updateWith([150, 1, 2])) // add bid
+    assert(ob.updateWith([100, 1, 1])) // add bid
+    assert(ob.updateWith([160, 1, 3])) // add bid
+
+    assert(ob.updateWith([161, 1, -3])) // add ask
+    assert(ob.updateWith([200, 1, -1])) // add ask
+    assert(ob.updateWith([175, 1, -2])) // add ask
+
+    assert.equal(ob.bids.length, 3)
+    assert.equal(ob.asks.length, 3)
+
+    assert.deepEqual(ob.bids, [
+      [160, 1, 3],
+      [150, 1, 2],
+      [100, 1, 1]
+    ])
+
+    assert.deepEqual(ob.asks, [
+      [161, 1, -3],
+      [175, 1, -2],
+      [200, 1, -1]
+    ])
+
+    assert(ob.updateWith([160, 2, 4])) // update top bid
+    assert.deepEqual(ob.bids, [
+      [160, 2, 4],
+      [150, 1, 2],
+      [100, 1, 1]
+    ])
+
+    assert(ob.updateWith([150, 0, 2])) // remove middle bid
+    assert.deepEqual(ob.bids, [
+      [160, 2, 4],
+      [100, 1, 1]
+    ])
+
+    assert(ob.updateWith([159, 1, 42])) // insert middle bid
+    assert.deepEqual(ob.bids, [
+      [160, 2, 4],
+      [159, 1, 42],
+      [100, 1, 1]
+    ])
+
+    assert(ob.updateWith([159.9, 2, 7])) // insert another bid
+    assert.deepEqual(ob.bids, [
+      [160, 2, 4],
+      [159.9, 2, 7],
+      [159, 1, 42],
+      [100, 1, 1]
+    ])
+
+    assert.deepEqual(ob.asks, [ // verify asks
+      [161, 1, -3],
+      [175, 1, -2],
+      [200, 1, -1]
+    ])
+
+    assert(ob.updateWith([161, 2, -4])) // update top ask
+    assert.deepEqual(ob.asks, [
+      [161, 2, -4],
+      [175, 1, -2],
+      [200, 1, -1]
+    ])
+
+    assert(ob.updateWith([175, 0, -2])) // remove middle ask
+    assert.deepEqual(ob.asks, [
+      [161, 2, -4],
+      [200, 1, -1]
+    ])
+
+    assert(ob.updateWith([175, 1, -42])) // insert middle ask
+    assert.deepEqual(ob.asks, [
+      [161, 2, -4],
+      [175, 1, -42],
+      [200, 1, -1]
+    ])
+
+    assert(ob.updateWith([170, 2, -7])) // insert another ask
+    assert.deepEqual(ob.asks, [
+      [161, 2, -4],
+      [170, 2, -7],
+      [175, 1, -42],
+      [200, 1, -1]
+    ])
+
+    assert.deepEqual(ob.bids, [ // verify bids
+      [160, 2, 4],
+      [159.9, 2, 7],
+      [159, 1, 42],
+      [100, 1, 1]
+    ])
+  })
+
+  it('updateWith: correctly applies update (raw books)', () => {
+    let _id = Date.now()
+    const id = () => _id++
+    const idBidA = id()
+    const idBidB = id()
+    const idBidC = id()
+    const idBidD = id()
+    const idBidE = id()
+    const idBidF = id()
+
+    const idAskA = id()
+    const idAskB = id()
+    const idAskC = id()
+    const idAskD = id()
+    const idAskE = id()
+    const idAskF = id()
+
+    const entries = [
+      [idBidA, 100, 10],
+      [idAskA, 200, -10]
+    ]
+
+    const ob = new OrderBook(entries, true)
+    assert(ob.updateWith([idBidA, 100, 15])) // update bid
+    assert(ob.updateWith([idAskA, 200, -15])) // update ask
+
+    assert.deepEqual(ob.bids, [[idBidA, 100, 15]])
+    assert.deepEqual(ob.asks, [[idAskA, 200, -15]])
+
+    assert(ob.updateWith([idBidA, 0, 15])) // remove bid
+    assert(ob.updateWith([idAskA, 0, -15])) // remove ask
+
+    assert.equal(ob.bids.length, 0)
+    assert.equal(ob.asks.length, 0)
+
+    assert(ob.updateWith([idBidC, 150, 2])) // add bid
+    assert(ob.updateWith([idBidB, 100, 1])) // add bid
+    assert(ob.updateWith([idBidD, 160, 3])) // add bid
+
+    assert(ob.updateWith([idAskD, 161, -3])) // add ask
+    assert(ob.updateWith([idAskB, 200, -1])) // add ask
+    assert(ob.updateWith([idAskC, 175, -2])) // add ask
+
+    assert.equal(ob.bids.length, 3)
+    assert.equal(ob.asks.length, 3)
+
+    assert.deepEqual(ob.bids, [
+      [idBidD, 160, 3],
+      [idBidC, 150, 2],
+      [idBidB, 100, 1]
+    ])
+
+    assert.deepEqual(ob.asks, [
+      [idAskD, 161, -3],
+      [idAskC, 175, -2],
+      [idAskB, 200, -1]
+    ])
+
+    assert(ob.updateWith([idBidD, 160, 4])) // update top bid
+    assert.deepEqual(ob.bids, [
+      [idBidD, 160, 4],
+      [idBidC, 150, 2],
+      [idBidB, 100, 1]
+    ])
+
+    assert(ob.updateWith([idBidC, 0, 2])) // remove middle bid
+    assert.deepEqual(ob.bids, [
+      [idBidD, 160, 4],
+      [idBidB, 100, 1]
+    ])
+
+    assert(ob.updateWith([idBidE, 159, 42])) // insert middle bid
+    assert.deepEqual(ob.bids, [
+      [idBidD, 160, 4],
+      [idBidE, 159, 42],
+      [idBidB, 100, 1]
+    ])
+
+    assert(ob.updateWith([idBidF, 159.9, 7])) // insert another bid
+    assert.deepEqual(ob.bids, [
+      [idBidD, 160, 4],
+      [idBidF, 159.9, 7],
+      [idBidE, 159, 42],
+      [idBidB, 100, 1]
+    ])
+
+    assert.deepEqual(ob.asks, [ // verify asks
+      [idAskD, 161, -3],
+      [idAskC, 175, -2],
+      [idAskB, 200, -1]
+    ])
+
+    assert(ob.updateWith([idAskD, 161, -4])) // update top ask
+    assert.deepEqual(ob.asks, [
+      [idAskD, 161, -4],
+      [idAskC, 175, -2],
+      [idAskB, 200, -1]
+    ])
+
+    assert(ob.updateWith([idAskC, 0, -2])) // remove middle ask
+    assert.deepEqual(ob.asks, [
+      [idAskD, 161, -4],
+      [idAskB, 200, -1]
+    ])
+
+    assert(ob.updateWith([idAskE, 165, -42])) // insert middle ask
+    assert.deepEqual(ob.asks, [
+      [idAskD, 161, -4],
+      [idAskE, 165, -42],
+      [idAskB, 200, -1]
+    ])
+
+    assert(ob.updateWith([idAskF, 162, -7])) // insert another ask
+    assert.deepEqual(ob.asks, [
+      [idAskD, 161, -4],
+      [idAskF, 162, -7],
+      [idAskE, 165, -42],
+      [idAskB, 200, -1]
+    ])
+
+    assert.deepEqual(ob.bids, [ // verify bids
+      [idBidD, 160, 4],
+      [idBidF, 159.9, 7],
+      [idBidE, 159, 42],
+      [idBidB, 100, 1]
+    ])
   })
 
   it('updateWith: maintains sort', () => {
     const ob = new OrderBook([
-      [100, 2, 10],
-      [200, 2, -10]
+      [100, 100, 10],
+      [200, 200, -10]
     ])
 
-    ob.updateWith([20, 5, 10])
-    ob.updateWith([150, 5, 10])
-    ob.updateWith([80, 5, 10])
-    ob.updateWith([300, 5, -10])
-    ob.updateWith([40, 5, 10])
-    ob.updateWith([130, 5, 10])
-    ob.updateWith([342, 5, -10])
-    ob.updateWith([457, 5, -10])
+    assert(ob.updateWith([20, 5, 10]))
+    assert(ob.updateWith([150, 5, 10]))
+    assert(ob.updateWith([80, 5, 10]))
+    assert(ob.updateWith([300, 5, -10]))
+    assert(ob.updateWith([40, 5, 10]))
+    assert(ob.updateWith([130, 5, 10]))
+    assert(ob.updateWith([342, 5, -10]))
+    assert(ob.updateWith([457, 5, -10]))
 
     for (let i = 0; i < ob.bids.length - 2; i++) {
       assert(ob.bids[i][0] > ob.bids[i + 1][0])
@@ -114,7 +338,7 @@ describe('OrderBook model', () => {
       done()
     })
 
-    ob.updateWith([20, 5, 10])
+    assert(ob.updateWith([20, 5, 10]))
   })
 
   it('midPrice: calculates mid price', () => {
@@ -180,17 +404,207 @@ describe('OrderBook model', () => {
       [200, 2, -10]
     ]
 
-    OrderBook.updateArrayOBWith(ob, [100, 0, 1])
-    OrderBook.updateArrayOBWith(ob, [150, 1, 16])
-    OrderBook.updateArrayOBWith(ob, [200, 7, -42])
-    OrderBook.updateArrayOBWith(ob, [121, 3, 14])
-    OrderBook.updateArrayOBWith(ob, [300, 1, -4])
-
+    assert(OrderBook.updateArrayOBWith(ob, [100, 0, 1])) // general manipulation
+    assert(OrderBook.updateArrayOBWith(ob, [150, 1, 16]))
+    assert(OrderBook.updateArrayOBWith(ob, [200, 7, -42]))
+    assert(OrderBook.updateArrayOBWith(ob, [121, 3, 14]))
+    assert(OrderBook.updateArrayOBWith(ob, [300, 1, -4]))
     assert.deepEqual(ob, [
       [300, 1, -4],
       [200, 7, -42],
       [150, 1, 16],
       [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [130, 1, 10])) // add middle bid
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [200, 7, -42],
+      [150, 1, 16],
+      [130, 1, 10],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [140, 1, 20])) // add another bid
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 20],
+      [130, 1, 10],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [140, 1, 42])) // update the new bid
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [130, 1, 10],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [130, 0, 42])) // remove a bid
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [250, 1, -10])) // add middle ask
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [250, 1, -10],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [220, 1, -20])) // add another ask
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [250, 1, -10],
+      [220, 1, -20],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [220, 1, -42])) // update the new ask
+    assert.deepEqual(ob, [
+      [300, 1, -4],
+      [250, 1, -10],
+      [220, 1, -42],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [121, 3, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [300, 0, -4])) // remove an ask
+    assert.deepEqual(ob, [
+      [250, 1, -10],
+      [220, 1, -42],
+      [200, 7, -42],
+      [150, 1, 16],
+      [140, 1, 42],
+      [121, 3, 14]
+    ])
+  })
+
+  it('updateArrayOBWith: correctly applies update (raw books)', () => {
+    let _id = Date.now()
+    const id = () => _id++
+    const idBidA = id()
+    const idBidB = id()
+    const idBidC = id()
+    const idAskA = id()
+    const idAskB = id()
+
+    const ob = [
+      [idBidA, 100, 10],
+      [idAskA, 200, -10]
+    ]
+
+    assert(OrderBook.updateArrayOBWith(ob, [idBidA, 0, 10], true)) // general manipulation
+    assert(OrderBook.updateArrayOBWith(ob, [idBidB, 150, 16], true))
+    assert(OrderBook.updateArrayOBWith(ob, [idAskA, 200, -42], true))
+    assert(OrderBook.updateArrayOBWith(ob, [idBidC, 121, 14], true))
+    assert(OrderBook.updateArrayOBWith(ob, [idAskB, 300, -4], true))
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidC, 121, 14]
+    ])
+
+    const idBidD = id()
+    assert(OrderBook.updateArrayOBWith(ob, [idBidD, 130, 10], true)) // add middle bid
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidD, 130, 10],
+      [idBidC, 121, 14]
+    ])
+
+    const idBidE = id()
+    assert(OrderBook.updateArrayOBWith(ob, [idBidE, 140, 20], true)) // add another bid
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 20],
+      [idBidD, 130, 10],
+      [idBidC, 121, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [idBidE, 140, 42], true)) // update the new bid
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidD, 130, 10],
+      [idBidC, 121, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [idBidD, 0, 42], true)) // remove a bid
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidC, 121, 14]
+    ])
+
+    const idAskC = id()
+    assert(OrderBook.updateArrayOBWith(ob, [idAskC, 250, -10], true)) // add middle ask
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskC, 250, -10],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidC, 121, 14]
+    ])
+
+    const idAskD = id()
+    assert(OrderBook.updateArrayOBWith(ob, [idAskD, 220, -20], true)) // add another ask
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskC, 250, -10],
+      [idAskD, 220, -20],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidC, 121, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [idAskD, 220, -42], true)) // update the new ask
+    assert.deepEqual(ob, [
+      [idAskB, 300, -4],
+      [idAskC, 250, -10],
+      [idAskD, 220, -42],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidC, 121, 14]
+    ])
+
+    assert(OrderBook.updateArrayOBWith(ob, [idAskB, 0, -4], true)) // remove an ask
+    assert.deepEqual(ob, [
+      [idAskC, 250, -10],
+      [idAskD, 220, -42],
+      [idAskA, 200, -42],
+      [idBidB, 150, 16],
+      [idBidE, 140, 42],
+      [idBidC, 121, 14]
     ])
   })
 


### PR DESCRIPTION
* [x] needs https://github.com/bitfinexcom/bitfinex-api-node/pull/286
* [x] closes #230

Adds checksum logic to the `OrderBook` model for both raw & normal OBs, along with automatic verification of tracked OBs on `WSv2`. The implementation is based off of the description provided here: http://blog.bitfinex.com/api/bitfinex-api-order-books-checksums/

For reference, the price level structure:
 * normal books (`P*`): `[price, count, amount]`
 * raw books (`R0`): `[orderID, price, amount]`

### Testing
1. setup `.env` file
2. run `node examples/ws2/ob_checksum.js`
3. wait for/spawn some OB updates and verify there are no errors in the output (the CS is logged)

While testing, keep in mind the fix for raw order book checksums is not yet on production :shipit: 