### PR TITLE
Feature: Add atomic order update support, closes #271

### DIFF
--- a/examples/ws2/atomic_order_update.js
+++ b/examples/ws2/atomic_order_update.js
@@ -1,0 +1,61 @@
+'use strict'
+
+process.env.DEBUG = '*' // 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:ws2_orders')
+const { Order } = require('../../lib/models')
+const bfx = require('../bfx')
+const ws = bfx.ws(2)
+
+ws.on('error', (err) => {
+  console.log(err)
+})
+
+ws.on('open', () => {
+  debug('open')
+  ws.auth()
+})
+
+ws.once('auth', () => {
+  debug('authenticated')
+
+  // Build new order
+  const o = new Order({
+    cid: Date.now(),
+    symbol: 'tBTCUSD',
+    price: 1000,
+    amount: 0.02,
+    type: Order.type.EXCHANGE_LIMIT
+  }, ws)
+
+  o.registerListeners()
+
+  o.on('update', () => {
+    debug('order updated: %j', o.serialize())
+  })
+
+  o.on('close', () => {
+    debug('order closed: %s', o.status)
+  })
+
+  debug('submitting order %d', o.cid)
+
+  o.submit().then(() => {
+    debug('got submit confirmation for order %d [%d]', o.cid, o.id)
+
+    // wait a bit...
+    setTimeout(() => {
+      debug('increasing amount by 0.02')
+
+      // atomic update
+      o.update({ delta: '0.02' }).then(() => {
+        debug('order update applied: %j', o.toJS())
+      })
+    }, 2000)
+  }).catch((err) => {
+    console.log(err)
+    ws.close()
+  })
+})
+
+ws.open()

--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -117,6 +117,47 @@ class Order extends Model {
   }
 
   /**
+   * Send an order update packet to the WS server, and update local state. This
+   * updates the order atomically without changing its position in the queue for
+   * its price level.
+   *
+   * Rejects with an error if an attempt is made to apply a delta to a missing
+   * amount.
+   *
+   * @param {Object} changes
+   * @param {WSv2} ws - optional, defaults to internal instance
+   * @return {Promise} p - resolves on ws2 confirmation, or rejects if no ws2
+   */
+  update (changes = {}, ws = this._ws) {
+    const keys = Object.keys(changes)
+
+    // Apply change locally
+    keys.forEach(k => {
+      if (k === 'id') return
+
+      if (FIELD_KEYS.indexOf(k) !== -1) {
+        this[k] = changes[k]
+      } else if (k === 'price_trailing') {
+        this.priceTrailing = Number(changes[k])
+      } else if (k === 'price_oco_stop' || k === 'price_aux_limit') {
+        this.priceAuxLimit = Number(changes[k])
+      } else if (k === 'delta' && !Number.isNaN(+changes[k])) {
+        if (!Number.isNaN(+this.amount)) {
+          this.amount += Number(changes[k])
+        } else {
+          return Promise.reject(new Error('can\'t apply delta to missing amount'))
+        }
+      }
+    })
+
+    changes.id = this.id // tag with ID
+
+    return ws
+      ? ws.updateOrder(changes)
+      : Promise.reject(new Error('no ws client available'))
+  }
+
+  /**
    * @return {Object} preview
    */
   toPreview () {

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -410,6 +410,15 @@ class WSv2 extends EventEmitter {
       }
 
       this._eventCallbacks.trigger(k, new Error(`${status}: ${msg}`), arrN[4])
+    } else if (arrN[1] === 'ou-req') {
+      const [id] = arrN[4]
+      const k = `order-update-${id}`
+
+      if (status === 'SUCCESS') {
+        return this._eventCallbacks.trigger(k, null, arrN[4])
+      }
+
+      this._eventCallbacks.trigger(k, new Error(`${status}: ${msg}`), arrN[4])
     }
   }
 
@@ -1262,6 +1271,28 @@ class WSv2 extends EventEmitter {
     this._sendOrderPacket([0, 'on', null, packet])
 
     return this._getEventPromise(`order-new-${packet.cid}`)
+  }
+
+  /**
+   * Send a changeset to update an order in-place while maintaining position in
+   * the price queue. The changeset must contain the order ID, and supports a
+   * 'delta' key to increase/decrease the total amount.
+   *
+   * @param {Object} changes - requires at least an 'id'
+   * @return {Promise} p - resolves on receival of confirmation notification
+   */
+  updateOrder (changes = {}) {
+    const { id } = changes
+
+    if (!this._isAuthenticated) {
+      return Promise.reject(new Error('not authenticated'))
+    } else if (!id) {
+      return Promise.reject(new Error('order ID required for update'))
+    }
+
+    this._sendOrderPacket([0, 'ou', null, changes])
+
+    return this._getEventPromise(`order-update-${id}`)
   }
 
   /**


### PR DESCRIPTION
#### Adds
* WS2 client method: `WSv2.updateOrder(changes = {}) -> Promise`
* Order model method: `Order.update(changes = {}, ws = this._ws) -> Promise`
* an example
* tests!

The order update method applies the changes to the order, and then forwards them along to any registered ws2 (or the one provided). The promise is rejected if no ws2 client is available.

The ws2 client method in turn passes it out to the socket, and returns an event promise triggered by the next `ou-req` notification that has a matching ID.

This means we can now do this:
```js
const o = new Order({
  cid: Date.now(),
  symbol: 'tBTCUSD',
  price: 1000,
  amount: 0.02,
  type: Order.type.EXCHANGE_LIMIT
}, ws)

// increase amount to 0.04 without cancelling the order
o.submit().then(() => {
  o.update({ delta: '0.02' }).then(() => {
    debug('order update applied: %j', o.toJS())
  })
})
```