### PR TITLE
Feature: Log server status when receiving info codes & on connect

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -922,19 +922,36 @@ class WSv2 extends EventEmitter {
    * @param {Object} msg
    * @private
    */
-  _handleInfoEvent (msg) {
-    if (msg.version) {
-      if (msg.version !== 2) {
-        const err = new Error(`server not running API v2: v${msg.version}`)
+  _handleInfoEvent (msg = {}) {
+    const { version, code } = msg
+
+    if (version) {
+      if (version !== 2) {
+        const err = new Error(`server not running API v2: v${version}`)
 
         this.emit('error', err)
         this.close()
         return
-      } else {
-        debug('server running API v2')
       }
-    } else if (msg.code && this._infoListeners[msg.code]) {
-      this._infoListeners[msg.code].forEach(cb => cb(msg))
+
+      const { status } = msg.platform || {}
+
+      debug(
+        'server running API v2 (platform: %s (%d))',
+        status === 0 ? 'under maintenance' : 'operating normally', status
+      )
+    } else if (code) {
+      if (this._infoListeners[code]) {
+        this._infoListeners[code].forEach(cb => cb(msg))
+      }
+
+      if (code === INFO_CODES.SERVER_RESTART) {
+        debug('server restarted, please reconnect')
+      } else if (code === INFO_CODES.MAINTENANCE_START) {
+        debug('server maintenance period started!')
+      } else if (code === INFO_CODES.MAINTENANCE_END) {
+        debug('server maintenance period ended!')
+      }
     }
 
     this.emit('info', msg)

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -1114,6 +1114,67 @@ describe('WSv2 event msg handling', () => {
     assert(Object.keys(ws._channelMap).length === 0)
   })
 
+  it('_handleInfoEvent: passes message to relevant listeners (raw access)', (done) => {
+    const wss = new MockWSv2Server()
+    const ws = createTestWSv2Instance()
+    ws.once('open', () => {
+      let n = 0
+
+      ws._infoListeners[42] = [
+        () => { n += 1 },
+        () => { n += 2 }
+      ]
+
+      ws._handleInfoEvent({ code: 42 })
+
+      assert.equal(n, 3)
+      wss.close()
+      done()
+    })
+
+    ws.open()
+  })
+
+  it('_handleInfoEvent: passes message to relevant listeners', (done) => {
+    const wss = new MockWSv2Server()
+    const ws = createTestWSv2Instance()
+    ws.once('open', () => {
+      let n = 0
+
+      ws.onInfoMessage(42, () => { n += 1 })
+      ws.onInfoMessage(42, () => { n += 2 })
+      ws._handleInfoEvent({ code: 42 })
+
+      assert.equal(n, 3)
+      wss.close()
+      done()
+    })
+
+    ws.open()
+  })
+
+  it('_handleInfoEvent: passes message to relevant named listeners', (done) => {
+    const wss = new MockWSv2Server()
+    const ws = createTestWSv2Instance()
+    ws.once('open', () => {
+      let n = 0
+
+      ws.onServerRestart(() => { n += 1 })
+      ws.onMaintenanceStart(() => { n += 10 })
+      ws.onMaintenanceEnd(() => { n += 100 })
+
+      ws._handleInfoEvent({ code: WSv2.info.SERVER_RESTART })
+      ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_START })
+      ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_END })
+
+      assert.equal(n, 111)
+      wss.close()
+      done()
+    })
+
+    ws.open()
+  })
+
   it('_handleInfoEvent: closes & emits error if not on api v2', (done) => {
     const wss = new MockWSv2Server()
     const ws = createTestWSv2Instance()


### PR DESCRIPTION
This commit is tiny, but closes #248 by checking the `platform.status` value on connection, and logging status updates.