### PR TITLE
Fix: Ensure ws client is reset before re-connecting

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -232,6 +232,8 @@ class WSv2 extends EventEmitter {
   reconnect () {
     if (!this._ws) return this.open()
 
+    this._isReconnecting = true
+
     return new Promise((resolve, reject) => {
       this._ws.once('close', () => {
         this._isOpen = false
@@ -1402,6 +1404,13 @@ class WSv2 extends EventEmitter {
    */
   isOpen () {
     return this._isOpen
+  }
+
+  /**
+   * @return {boolean} reconnecting
+   */
+  isReconnecting () {
+    return this._isReconnecting
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -178,6 +178,9 @@ class WSv2 extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this._ws.once('close', () => {
+        this._isOpen = false
+        this._ws = null
+
         debug('disconnected')
         resolve()
       })
@@ -235,10 +238,7 @@ class WSv2 extends EventEmitter {
     this._isReconnecting = true
 
     return new Promise((resolve, reject) => {
-      this._ws.once('close', () => {
-        this._isOpen = false
-        this._ws = null
-
+      this.close().then(() => {
         this.open()
 
         if (!this._wasEverAuthenticated) {
@@ -248,8 +248,6 @@ class WSv2 extends EventEmitter {
         this._ws.once('open', this.auth.bind(this))
         this._ws.once('auth', () => resolve())
       })
-
-      this.close()
     })
   }
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -139,6 +139,7 @@ class WSv2 extends EventEmitter {
     this._ws = new WebSocket(this._url, {
       agent: this._agent
     })
+
     this._subscriptionRefs = {}
     this._candles = {}
     this._orderBooks = {}
@@ -233,6 +234,9 @@ class WSv2 extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this._ws.once('close', () => {
+        this._isOpen = false
+        this._ws = null
+
         this.open()
 
         if (!this._wasEverAuthenticated) {

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -120,6 +120,26 @@ describe('WSv2 lifetime', () => {
     })
   })
 
+  it('close: clears connection state', (done) => {
+    const wss = new MockWSv2Server()
+    const ws = createTestWSv2Instance()
+    ws._onWSClose = () => {} // disable fallback reset
+
+    ws.open()
+    ws.on('open', () => {
+      assert(ws._ws !== null)
+      assert(ws._isOpen)
+
+      ws.close().then(() => {
+        assert(ws._ws == null)
+        assert(!ws._isOpen)
+
+        wss.close()
+        done()
+      })
+    })
+  })
+
   it('auth: fails to auth twice', (done) => {
     const wss = new MockWSv2Server()
     const ws = createTestWSv2Instance()


### PR DESCRIPTION
I also added in `isReconnecting()` & updated the flag internally, since it was unused before. Closes #291 

Previously, `_isOpen` would have been `true` if the `_onWSClose()` handler didn't have a chance to fire.