### PR TITLE
Feature: Better atomic update example & new helpers

### DIFF
--- a/examples/ws2/atomic_order_update.js
+++ b/examples/ws2/atomic_order_update.js
@@ -1,61 +1,75 @@
 'use strict'
 
-process.env.DEBUG = '*' // 'bfx:examples:*'
+process.env.DEBUG = 'bfx:examples:*'
 
-const debug = require('debug')('bfx:examples:ws2_orders')
+const debug = require('debug')('bfx:examples:update_order')
 const { Order } = require('../../lib/models')
 const bfx = require('../bfx')
-const ws = bfx.ws(2)
+const ws = bfx.ws(2, {
+  transform: true,
+  manageOrderBooks: true,
 
-ws.on('error', (err) => {
-  console.log(err)
+  packetWDDelay: 10 * 1000,
+  autoReconnect: true,
+  seqAudit: true
 })
+
+const SYMBOL = 'tBTCUSD'
 
 ws.on('open', () => {
   debug('open')
   ws.auth()
 })
 
-ws.once('auth', () => {
-  debug('authenticated')
+ws.on('auth', () => {
+  debug('auth')
 
-  // Build new order
+  ws.subscribeOrderBook(SYMBOL, 'P0', '25')
+  debug('subscribed to order book %s:P0:25', SYMBOL)
+})
+
+let orderSent = false
+
+ws.onOrderBook({ symbol: SYMBOL }, (ob) => {
+  const topBidL = ob.topBidLevel()
+
+  if (topBidL === null || orderSent) {
+    return
+  }
+
+  debug('taking out price level: %j', topBidL)
+
   const o = new Order({
-    cid: Date.now(),
-    symbol: 'tBTCUSD',
-    price: 1000,
-    amount: 0.02,
-    type: Order.type.EXCHANGE_LIMIT
+    symbol: SYMBOL,
+    type: Order.type.EXCHANGE_LIMIT,
+    price: topBidL[0],
+    amount: topBidL[2] * -1.1 // sell through top bid
   }, ws)
 
   o.registerListeners()
+  o.submit().then(() => debug('order submitted'))
+  o.once('update', (o) => {
+    debug('got order update: %s', o.status)
 
-  o.on('update', () => {
-    debug('order updated: %j', o.serialize())
-  })
+    if (o.isPartiallyFilled()) {
+      debug('order is partially filled, amount %f', o.amount)
+      debug('increasing amount w/ delta %f', o.amount * 2)
 
-  o.on('close', () => {
-    debug('order closed: %s', o.status)
-  })
+      o.update({ delta: `${o.amount * 2}` }).then(() => {
+        debug('order updated, new amount %f', o.amount)
+        debug('setting price to %f', o.price * 1.05)
 
-  debug('submitting order %d', o.cid)
+        o.update({ price: `${o.price * 1.05}` }).then(() => {
+          debug('order updated, new price %f', o.price)
 
-  o.submit().then(() => {
-    debug('got submit confirmation for order %d [%d]', o.cid, o.id)
-
-    // wait a bit...
-    setTimeout(() => {
-      debug('increasing amount by 0.02')
-
-      // atomic update
-      o.update({ delta: '0.02' }).then(() => {
-        debug('order update applied: %j', o.toJS())
+          debug('closing connection')
+          ws.close()
+        })
       })
-    }, 2000)
-  }).catch((err) => {
-    console.log(err)
-    ws.close()
+    }
   })
+
+  orderSent = true
 })
 
 ws.open()

--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -283,6 +283,14 @@ class Order extends Model {
   }
 
   /**
+   * @return {boolean} isPartiallyFilled
+   */
+  isPartiallyFilled () {
+    const a = Math.abs(this.amount)
+    return a > 0 && a < Math.abs(this.amountOrig)
+  }
+
+  /**
    * @param {Array} order
    * @private
    */
@@ -301,6 +309,7 @@ class Order extends Model {
     this._lastAmount = this.amount
     Object.assign(this, Order.unserialize(order))
 
+    this.emit('update', order, this)
     this.emit('close', order, this)
   }
 
@@ -313,6 +322,7 @@ class Order extends Model {
     Object.assign(this, Order.unserialize(order))
 
     this.emit('update', order, this)
+    this.emit('new', order, this)
   }
 
   /**

--- a/lib/models/order_book.js
+++ b/lib/models/order_book.js
@@ -202,6 +202,36 @@ class OrderBook extends EventEmitter {
   }
 
   /**
+   * @return {number} topBid - may be null
+   */
+  topBid () {
+    const priceI = this.raw ? 1 : 0
+    return (this.topBidLevel() || [])[priceI] || null
+  }
+
+  /**
+   * @return {number} topBidLevel - may be null
+   */
+  topBidLevel () {
+    return this.bids[0] || null
+  }
+
+  /**
+   * @return {number} topAsk - may be null
+   */
+  topAsk () {
+    const priceI = this.raw ? 1 : 0
+    return (this.topAskLevel() || [])[priceI] || null
+  }
+
+  /**
+   * @return {number} topAskLevel - may be null
+   */
+  topAskLevel () {
+    return this.asks[0] || null
+  }
+
+  /**
    * @return {number} price
    */
   midPrice () {

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -346,6 +346,12 @@ describe('Order model', () => {
     o._onWSOrderClose([42])
   })
 
+  it('_onWSOrderClose: emits update event', (done) => {
+    const o = new Order({ id: 100 })
+    o.on('update', () => done())
+    o._onWSOrderClose([42])
+  })
+
   it('_onWSOrderNew: updates last fill amount', () => {
     testHandlerFillUpdate('_onWSOrderNew')
   })
@@ -359,6 +365,12 @@ describe('Order model', () => {
   it('_onWSOrderNew: emits update event', (done) => {
     const o = new Order({ id: 100 })
     o.on('update', () => done())
+    o._onWSOrderNew([42])
+  })
+
+  it('_onWSOrderNew: emits new event', (done) => {
+    const o = new Order({ id: 100 })
+    o.on('new', () => done())
     o._onWSOrderNew([42])
   })
 
@@ -537,5 +549,11 @@ describe('Order model', () => {
     })
 
     o.update({ test: 42 }).catch(done)
+  })
+
+  it('isPartiallyFilled: returns true if the order is partially filled', () => {
+    assert(new Order({ amount: 5, amountOrig: 25 }).isPartiallyFilled())
+    assert(!new Order({ amount: 0, amountOrig: 25 }).isPartiallyFilled())
+    assert(!new Order({ amount: 25, amountOrig: 25 }).isPartiallyFilled())
   })
 })

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -18,6 +18,38 @@ describe('OrderBook model', () => {
     assert.deepEqual(ob.asks, [entries[1]])
   })
 
+  it('topBid/topAsk: returns the top bid/ask, or null', () => {
+    const ob = new OrderBook([
+      [140, 1, 10],
+      [145, 1, 10],
+      [148, 1, 10],
+      [149, 1, 10],
+      [151, 1, -10],
+      [152, 1, -10],
+      [158, 1, -10],
+      [160, 1, -10]
+    ])
+
+    assert.equal(ob.topBid(), 149)
+    assert.equal(ob.topAsk(), 151)
+  })
+
+  it('topBidLevel/topAskLevel: returns the top bid/ask levels, or null', () => {
+    const ob = new OrderBook([
+      [140, 1, 10],
+      [145, 1, 10],
+      [148, 1, 10],
+      [149, 1, 10],
+      [151, 1, -10],
+      [152, 1, -10],
+      [158, 1, -10],
+      [160, 1, -10]
+    ])
+
+    assert.deepEqual(ob.topBidLevel(), [149, 1, 10])
+    assert.deepEqual(ob.topAskLevel(), [151, 1, -10])
+  })
+
   it('checksum: returns expected value for normal OB', () => {
     const ob = new OrderBook({
       bids: [[6000, 1, 1], [5900, 1, 2]],


### PR DESCRIPTION
I tweaked the atomic order update example to showcase updates to partially filled orders. The example sells through the top bid in the OB, and then modifies the resulting order by increasing the price & the amount.

I've also added a few helper methods along with tests, and the order now emits an `update` event on close, and a `new` event after receiving a matching `on` packet. An `update` event is now emitted for all three listeners (new/update/close).

closes #300 