### PR TITLE
Fix: Funding model indices

### DIFF
--- a/examples/rest2/funding_credits.js
+++ b/examples/rest2/funding_credits.js
@@ -1,0 +1,15 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:funding_credits')
+const bfx = require('../bfx')
+const rest = bfx.rest(2)
+
+debug('fetching funding credits...')
+
+rest.fundingCredits('fUSD').then(fcs => {
+  fcs.forEach(fc => {
+    debug('fc: %j', fc)
+  })
+}).catch(debug)

--- a/examples/rest2/funding_loans.js
+++ b/examples/rest2/funding_loans.js
@@ -1,0 +1,15 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:funding_loans')
+const bfx = require('../bfx')
+const rest = bfx.rest(2)
+
+debug('fetching funding loans...')
+
+rest.fundingLoans('fUSD').then(fls => {
+  fls.forEach(fl => {
+    debug('fl: %j', fl)
+  })
+}).catch(debug)

--- a/examples/rest2/funding_offers.js
+++ b/examples/rest2/funding_offers.js
@@ -1,0 +1,15 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:funding_offers')
+const bfx = require('../bfx')
+const rest = bfx.rest(2)
+
+debug('fetching funding offers...')
+
+rest.fundingOffers('fUSD').then(fos => {
+  fos.forEach(fo => {
+    debug('fo: %j', fo)
+  })
+}).catch(debug)

--- a/lib/models/funding_credit.js
+++ b/lib/models/funding_credit.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Model = require('../model')
-const BOOL_FIELDS = ['notify', 'hidden', 'insure', 'renew', 'noClose']
+const BOOL_FIELDS = ['notify', 'hidden', 'renew', 'noClose']
 const FIELDS = {
   id: 0,
   symbol: 1,
@@ -11,17 +11,16 @@ const FIELDS = {
   amount: 5,
   flags: 6,
   status: 7,
-  rate: 8,
-  period: 9,
-  mtsOpening: 10,
-  mtsLastPayout: 11,
-  notify: 12,
-  hidden: 13,
-  insure: 14,
-  renew: 15,
-  rateReal: 16,
-  noClose: 17,
-  positionPair: 18
+  rate: 11,
+  period: 12,
+  mtsOpening: 13,
+  mtsLastPayout: 14,
+  notify: 15,
+  hidden: 16,
+  renew: 18,
+  rateReal: 19,
+  noClose: 20,
+  positionPair: 21
 }
 
 const FIELD_KEYS = Object.keys(FIELDS)

--- a/lib/models/funding_loan.js
+++ b/lib/models/funding_loan.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Model = require('../model')
-const BOOL_FIELDS = ['notify', 'hidden', 'insure', 'renew', 'noClose']
+const BOOL_FIELDS = ['notify', 'hidden', 'renew', 'noClose']
 const FIELDS = {
   id: 0,
   symbol: 1,
@@ -11,16 +11,15 @@ const FIELDS = {
   amount: 5,
   flags: 6,
   status: 7,
-  rate: 8,
-  period: 9,
-  mtsOpening: 10,
-  mtsLastPayout: 11,
-  notify: 12,
-  hidden: 13,
-  insure: 14,
-  renew: 15,
-  rateReal: 16,
-  noClose: 17
+  rate: 11,
+  period: 12,
+  mtsOpening: 13,
+  mtsLastPayout: 14,
+  notify: 15,
+  hidden: 16,
+  renew: 18,
+  rateReal: 19,
+  noClose: 20
 }
 
 const FIELD_KEYS = Object.keys(FIELDS)

--- a/lib/models/funding_offer.js
+++ b/lib/models/funding_offer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Model = require('../model')
-const BOOL_FIELDS = ['notify', 'hidden', 'insure', 'renew']
+const BOOL_FIELDS = ['notify', 'hidden', 'renew']
 const FIELDS = {
   id: 0,
   symbol: 1,
@@ -10,15 +10,14 @@ const FIELDS = {
   amount: 4,
   amountOrig: 5,
   type: 6,
-  flags: 7,
-  status: 8,
-  rate: 9,
-  period: 10,
-  notify: 11,
-  hidden: 12,
-  insure: 13,
-  renew: 14,
-  rateReal: 15
+  flags: 9,
+  status: 10,
+  rate: 14,
+  period: 15,
+  notify: 16,
+  hidden: 17,
+  renew: 19,
+  rateReal: 20
 }
 
 const FIELD_KEYS = Object.keys(FIELDS)

--- a/test/lib/models/funding_credit.js
+++ b/test/lib/models/funding_credit.js
@@ -7,11 +7,12 @@ const testModel = require('../../helpers/test_model')
 describe('FundingCredit model', () => {
   testModel({
     model: FundingCredit,
-    boolFields: ['notify', 'hidden', 'insure', 'renew', 'noClose'],
+    boolFields: ['notify', 'hidden', 'renew', 'noClose'],
     orderedFields: [
       'id', 'symbol', 'side', 'mtsCreate', 'mtsUpdate', 'amount', 'flags',
-      'status', 'rate', 'period', 'mtsOpening', 'mtsLastPayout', 'notify',
-      'hidden', 'insure', 'renew', 'rateReal', 'noClose', 'positionPair'
+      'status', null, null, null, 'rate', 'period', 'mtsOpening',
+      'mtsLastPayout', 'notify', 'hidden', null, 'renew', 'rateReal', 'noClose',
+      'positionPair'
     ]
   })
 })

--- a/test/lib/models/funding_loan.js
+++ b/test/lib/models/funding_loan.js
@@ -7,11 +7,11 @@ const testModel = require('../../helpers/test_model')
 describe('FundingLoan model', () => {
   testModel({
     model: FundingLoan,
-    boolFields: ['notify', 'hidden', 'insure', 'renew', 'noClose'],
+    boolFields: ['notify', 'hidden', 'renew', 'noClose'],
     orderedFields: [
       'id', 'symbol', 'side', 'mtsCreate', 'mtsUpdate', 'amount', 'flags',
-      'status', 'rate', 'period', 'mtsOpening', 'mtsLastPayout', 'notify',
-      'hidden', 'insure', 'renew', 'rateReal', 'noClose'
+      'status', null, null, null, 'rate', 'period', 'mtsOpening',
+      'mtsLastPayout', 'notify', 'hidden', null, 'renew', 'rateReal', 'noClose'
     ]
   })
 })

--- a/test/lib/models/funding_offer.js
+++ b/test/lib/models/funding_offer.js
@@ -7,11 +7,11 @@ const testModel = require('../../helpers/test_model')
 describe('FundingOffer model', () => {
   testModel({
     model: FundingOffer,
-    boolFields: ['notify', 'hidden', 'insure', 'renew'],
+    boolFields: ['notify', 'hidden', 'renew'],
     orderedFields: [
       'id', 'symbol', 'mtsCreate', 'mtsUpdate', 'amount', 'amountOrig', 'type',
-      'flags', 'status', 'rate', 'period', 'notify', 'hidden', 'insure',
-      'renew', 'rateReal'
+      null, null, 'flags', 'status', null, null, null, 'rate', 'period',
+      'notify', 'hidden', null, 'renew', 'rateReal'
     ]
   })
 })

--- a/test/lib/transports/rest-2-integration.js
+++ b/test/lib/transports/rest-2-integration.js
@@ -24,6 +24,11 @@ const getTestFundingLoan = () => ([
   null, null, 0.002, 7, 1524786468000, 1524786468000, 0, 0, null, 0, 0.002, 0
 ])
 
+const getTestFundingCredit = () => ([
+  26190108, 'fUSD', -1, 1524846786000, 1524846786000, 32.91281465, 0, 'ACTIVE',
+  null, null, null, 0.002, 7, 1524786468000, null, 0, 0, null, 0, 0.002, 0, null
+])
+
 const auditTestFundingOffer = (fo = {}) => {
   assert.equal(fo.id, 41215275)
   assert.equal(fo.symbol, 'fUSD')
@@ -60,6 +65,27 @@ const auditTestFundingLoan = (fl = {}) => {
   assert.equal(fl.renew, 0)
   assert.equal(fl.rateReal, 0.002)
   assert.equal(fl.noClose, 0)
+}
+
+const auditTestFundingCredit = (fc = {}) => {
+  assert.equal(fc.id, 26190108)
+  assert.equal(fc.symbol, 'fUSD')
+  assert.equal(fc.side, -1)
+  assert.equal(fc.mtsCreate, 1524846786000)
+  assert.equal(fc.mtsUpdate, 1524846786000)
+  assert.equal(fc.amount, 32.91281465)
+  assert.equal(fc.flags, 0)
+  assert.equal(fc.status, 'ACTIVE')
+  assert.equal(fc.rate, 0.002)
+  assert.equal(fc.period, 7)
+  assert.equal(fc.mtsOpening, 1524786468000)
+  assert.equal(fc.mtsLastPayout, null)
+  assert.equal(fc.notify, 0)
+  assert.equal(fc.hidden, 0)
+  assert.equal(fc.renew, 0)
+  assert.equal(fc.rateReal, 0.002)
+  assert.equal(fc.noClose, 0)
+  assert.equal(fc.positionPair, null)
 }
 
 describe('RESTv2 integration (mock server) tests', () => {
@@ -134,6 +160,18 @@ describe('RESTv2 integration (mock server) tests', () => {
 
     r.fundingLoans('fUSD').then(([fo]) => {
       auditTestFundingLoan(fo)
+      return srv.close()
+    }).then(done).catch(done)
+  })
+
+  it('correctly parses funding credit response', (done) => {
+    const srv = new MockRESTv2Server({ listen: true })
+    const r = getTestREST2({ transform: true })
+
+    srv.setResponse('f_credits.fUSD', [getTestFundingCredit()])
+
+    r.fundingCredits('fUSD').then(([fc]) => {
+      auditTestFundingCredit(fc)
       return srv.close()
     }).then(done).catch(done)
   })

--- a/test/lib/transports/rest-2-integration.js
+++ b/test/lib/transports/rest-2-integration.js
@@ -5,12 +5,61 @@ const assert = require('assert')
 const RESTv2 = require('../../../lib/transports/rest2')
 const { MockRESTv2Server } = require('bfx-api-mock-srv')
 
-const getTestREST2 = () => {
+const getTestREST2 = (args = {}) => {
   return new RESTv2({
     apiKey: 'dummy',
     apiSecret: 'dummy',
-    url: 'http://localhost:9999'
+    url: 'http://localhost:9999',
+    ...args
   })
+}
+
+const getTestFundingOffer = () => ([
+  41215275, 'fUSD', 1524784806000, 1524784806000, 1000, 1000, 'FRRDELTAVAR',
+  null, null, 0, 'ACTIVE', null, null, null, 0, 30, 0, 0, null, 0, 0.00207328
+])
+
+const getTestFundingLoan = () => ([
+  2993678, 'fUSD', -1, 1524786468000, 1524786468000, 200, 0, 'ACTIVE', null,
+  null, null, 0.002, 7, 1524786468000, 1524786468000, 0, 0, null, 0, 0.002, 0
+])
+
+const auditTestFundingOffer = (fo = {}) => {
+  assert.equal(fo.id, 41215275)
+  assert.equal(fo.symbol, 'fUSD')
+  assert.equal(fo.mtsCreate, 1524784806000)
+  assert.equal(fo.mtsUpdate, 1524784806000)
+  assert.equal(fo.amount, 1000)
+  assert.equal(fo.amountOrig, 1000)
+  assert.equal(fo.type, 'FRRDELTAVAR')
+  assert.equal(fo.flags, 0)
+  assert.equal(fo.status, 'ACTIVE')
+  assert.equal(fo.rate, 0)
+  assert.equal(fo.period, 30)
+  assert.equal(fo.notify, 0)
+  assert.equal(fo.hidden, 0)
+  assert.equal(fo.renew, 0)
+  assert.equal(fo.rateReal, 0.00207328)
+}
+
+const auditTestFundingLoan = (fl = {}) => {
+  assert.equal(fl.id, 2993678)
+  assert.equal(fl.symbol, 'fUSD')
+  assert.equal(fl.side, -1)
+  assert.equal(fl.mtsCreate, 1524786468000)
+  assert.equal(fl.mtsUpdate, 1524786468000)
+  assert.equal(fl.amount, 200)
+  assert.equal(fl.flags, 0)
+  assert.equal(fl.status, 'ACTIVE')
+  assert.equal(fl.rate, 0.002)
+  assert.equal(fl.period, 7)
+  assert.equal(fl.mtsOpening, 1524786468000)
+  assert.equal(fl.mtsLastPayout, 1524786468000)
+  assert.equal(fl.notify, 0)
+  assert.equal(fl.hidden, 0)
+  assert.equal(fl.renew, 0)
+  assert.equal(fl.rateReal, 0.002)
+  assert.equal(fl.noClose, 0)
 }
 
 describe('RESTv2 integration (mock server) tests', () => {
@@ -63,5 +112,29 @@ describe('RESTv2 integration (mock server) tests', () => {
 
       r[name].apply(r, args)
     })
+  })
+
+  it('correctly parses funding offer response', (done) => {
+    const srv = new MockRESTv2Server({ listen: true })
+    const r = getTestREST2({ transform: true })
+
+    srv.setResponse('f_offers.fUSD', [getTestFundingOffer()])
+
+    r.fundingOffers('fUSD').then(([fo]) => {
+      auditTestFundingOffer(fo)
+      return srv.close()
+    }).then(done).catch(done)
+  })
+
+  it('correctly parses funding loan response', (done) => {
+    const srv = new MockRESTv2Server({ listen: true })
+    const r = getTestREST2({ transform: true })
+
+    srv.setResponse('f_loans.fUSD', [getTestFundingLoan()])
+
+    r.fundingLoans('fUSD').then(([fo]) => {
+      auditTestFundingLoan(fo)
+      return srv.close()
+    }).then(done).catch(done)
   })
 })


### PR DESCRIPTION
The indices for `FundingOffer`, `FundingLoan` and `FundingCredit` have been updated on the API side, this PR fixes the model field indices. The `'insure'` field has been removed.

I've included 3 minor examples that log funding offers/credit/loands to the console. Once #228 is merged in I will migrate them to the table format as well (another PR)

#### TODO
- [x] capture a `FundingCredit` ws packet to verify `'insure'` removed

#### Closes
- #200 