### PR TITLE
Fix: Prepare/cast order update fields

### DIFF
--- a/lib/models/order.js
+++ b/lib/models/order.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird')
 const Model = require('../model')
+const { prepareAmount, preparePrice } = require('../util/precision')
 const BOOL_FIELDS = ['notify']
 const FIELDS = {
   id: 0,
@@ -151,6 +152,17 @@ class Order extends Model {
     })
 
     changes.id = this.id // tag with ID
+
+    if (changes.price) changes.price = preparePrice(changes.price)
+    if (changes.amount) changes.amount = prepareAmount(changes.amount)
+    if (changes.delta) changes.delta = prepareAmount(changes.delta)
+    if (changes.price_aux_limit) {
+      changes.price_aux_limit = preparePrice(changes.price_aux_limit)
+    }
+
+    if (changes.price_trailing) {
+      changes.price_trailing = preparePrice(changes.price_trailing)
+    }
 
     return ws
       ? ws.updateOrder(changes)

--- a/test/lib/models/order.js
+++ b/test/lib/models/order.js
@@ -531,6 +531,63 @@ describe('Order model', () => {
     done()
   })
 
+  it('update: prepares price & amount', (done) => {
+    const o = new Order({
+      price: 42,
+      amount: 1
+    }, {
+      updateOrder: (changes) => {
+        assert.strictEqual(changes.price, '43.000')
+        assert.strictEqual(changes.amount, '3.00000000')
+        done()
+      }
+    })
+
+    o.update({ price: 43, amount: 3 })
+  })
+
+  it('update: prepares delta', (done) => {
+    const o = new Order({
+      price: 42,
+      amount: 1
+    }, {
+      updateOrder: (changes) => {
+        assert.strictEqual(changes.delta, '3.00000000')
+        done()
+      }
+    })
+
+    o.update({ delta: 3 })
+  })
+
+  it('update: prepares aux limit price', (done) => {
+    const o = new Order({
+      price: 42,
+      amount: 1
+    }, {
+      updateOrder: (changes) => {
+        assert.strictEqual(changes.price_aux_limit, '3.0000')
+        done()
+      }
+    })
+
+    o.update({ price_aux_limit: 3 })
+  })
+
+  it('update: prepares trailing price', (done) => {
+    const o = new Order({
+      price: 42,
+      amount: 1
+    }, {
+      updateOrder: (changes) => {
+        assert.strictEqual(changes.price_trailing, '43.000')
+        done()
+      }
+    })
+
+    o.update({ price_trailing: 43 })
+  })
+
   it('update: rejects with error if applying delta to missing amount', (done) => {
     const o = new Order()
 


### PR DESCRIPTION
Previously you had to ensure the changeset price/amount fields were correctly formatted before submission; this now happens automatically.