### PR TITLE
Fix: Calc avail balance endpoint URL

### DIFF
--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -582,7 +582,7 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-calc-bal-avail
    */
   calcAvailableBalance (symbol = 'tBTCUSD', dir, rate, type, cb) {
-    return this._makeAuthRequest('/auth/r/calc/order/avail', {
+    return this._makeAuthRequest('/auth/calc/order/avail', {
       symbol,
       dir,
       rate,


### PR DESCRIPTION
Removes the '/r/' from '/auth/r/calc/order/avail', closes #292 

Needs https://github.com/bitfinexcom/bfx-api-mock-srv/pull/4 for tests to fail/pass with the change