### PR TITLE
Feature: Add notifyUI() Helper for WSv2

### DIFF
--- a/examples/ws2/notify_ui.js
+++ b/examples/ws2/notify_ui.js
@@ -1,0 +1,27 @@
+'use strict'
+
+process.env.DEBUG = '*'
+
+const debug = require('debug')('bfx:examples:notify_ui')
+const bfx = require('../bfx')
+const ws = bfx.ws(2)
+
+ws.on('error', (err) => {
+  console.log(err)
+})
+
+ws.on('open', () => {
+  debug('open')
+  ws.auth()
+})
+
+ws.once('auth', () => {
+  debug('authenticated')
+  debug('generating notification')
+  ws.notifyUI('success', 'This is a test notification sent via the WSv2 API')
+  debug('notification sent')
+
+  ws.close()
+})
+
+ws.open()

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -7,6 +7,7 @@ const Promise = require('bluebird')
 const CbQ = require('cbq')
 const { isFinite } = require('lodash')
 const _Throttle = require('lodash.throttle')
+const _isString = require('lodash/isString')
 const { genAuthSig, nonce } = require('../util')
 const getMessagePayload = require('../util/ws2')
 
@@ -1516,6 +1517,38 @@ class WSv2 extends EventEmitter {
    */
   isReconnecting () {
     return this._isReconnecting
+  }
+
+  /**
+   * Sends a broadcast notification, which will be received by any active UI
+   * websocket connections (at bitfinex.com), triggering a desktop notification.
+   * 
+   * In the future our mobile app will also support spawning native push
+   * notifications in response to incoming ucm-notify-ui packets.
+   *
+   * @param {string} type
+   * @param {string} message
+   */
+  notifyUI (type, message) {
+    if (!_isString(type) || !_isString(message)) {
+      throw new Error(`notified with invalid type/message: ${type}/${message}`)
+    }
+
+    if (!this._isOpen) {
+      throw new Error('socket not open')
+    }
+
+    if (!this._isAuthenticated) {
+      throw new Error('socket not authenticated')
+    }
+
+    this.send([0, 'n', null, {
+      type: 'ucm-notify-ui',
+      info: {
+        type,
+        message,
+      }
+    }])
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1522,7 +1522,7 @@ class WSv2 extends EventEmitter {
   /**
    * Sends a broadcast notification, which will be received by any active UI
    * websocket connections (at bitfinex.com), triggering a desktop notification.
-   * 
+   *
    * In the future our mobile app will also support spawning native push
    * notifications in response to incoming ucm-notify-ui packets.
    *
@@ -1546,7 +1546,7 @@ class WSv2 extends EventEmitter {
       type: 'ucm-notify-ui',
       info: {
         type,
-        message,
+        message
       }
     }])
   }


### PR DESCRIPTION
Adds a `notifyUI(type, message)` method on the `WSv2` class, which sends a broadcast notification out which can be detected by any open `bitfinex.com` UI client, triggering a desktop notification. In the future, the mobile apps will also support the creation of push notifications in response to incoming broadcast notifications.