### PR TITLE
Feature: Paginate Ledgers/Movements RESTv2

### DIFF
--- a/examples/rest2/ledgers.js
+++ b/examples/rest2/ledgers.js
@@ -4,16 +4,10 @@ process.env.DEBUG = 'bfx:examples:*'
 
 const args = process.argv
 const debug = require('debug')('bfx:examples:rest2-ledgers')
-
-if (args.length < 3) {
-  debug('error: symbol required (i.e: npm run ledgers ETH')
-  process.exit(1)
-}
-
 const Table = require('cli-table2')
 const bfx = require('../bfx')
 const rest = bfx.rest(2, { transform: true })
-const ccy = String(args[2])
+const ccy = args.length < 3 ? null : String(args[2])
 
 const table = new Table({
   colWidths: [12, 12, 20, 14, 14, 80],
@@ -22,16 +16,17 @@ const table = new Table({
   ]
 })
 
-debug('fetching ledger entries for %s...', ccy)
+debug('fetching ledger entries for %s...', ccy || 'all currencies')
 
 rest.ledgers(ccy).then(entries => {
-  let o
+  let e
 
   for (let i = 0; i < entries.length; i += 1) {
-    o = entries[i]
+    e = entries[i]
 
     table.push([
-      o[0], o[1], new Date(o[3]).toLocaleString(), o[5], o[6], o[8]
+      e.id, e.currency, new Date(e.mts).toLocaleString(), e.amount, e.balance,
+      e.description
     ])
   }
 

--- a/examples/rest2/movements.js
+++ b/examples/rest2/movements.js
@@ -4,16 +4,10 @@ process.env.DEBUG = 'bfx:examples:*'
 
 const args = process.argv
 const debug = require('debug')('bfx:examples:rest2-movements')
-
-if (args.length < 3) {
-  debug('error: symbol required (i.e: npm run movements ETH')
-  process.exit(1)
-}
-
 const Table = require('cli-table2')
 const bfx = require('../bfx')
 const rest = bfx.rest(2, { transform: true })
-const ccy = String(args[2])
+const ccy = args.length < 3 ? null : String(args[2])
 
 const table = new Table({
   colWidths: [12, 12, 20, 20, 20, 14, 14, 20, 20],
@@ -23,20 +17,21 @@ const table = new Table({
   ]
 })
 
-debug('fetching movements for %s...', ccy)
+debug('fetching movements for %s...', ccy || 'all currencies')
 
 rest.movements(ccy).then(movements => {
-  let o
+  let m
 
   for (let i = 0; i < movements.length; i += 1) {
-    o = movements[i]
+    m = movements[i]
 
-    const status = `${o[9][0].toUpperCase()}${o[9].substring(1).toLowerCase()}`
-    const started = new Date(o[5]).toLocaleString()
-    const updated = new Date(o[6]).toLocaleString()
+    const status = `${m.status[0].toUpperCase()}${m.status.substring(1).toLowerCase()}`
+    const started = new Date(m.mtsStarted).toLocaleString()
+    const updated = new Date(m.mtsUpdated).toLocaleString()
 
     table.push([
-      o[0], o[2], started, updated, status, o[12], o[13], o[16], o[20]
+      m.id, m.currency, started, updated, status, m.amount, m.fees,
+      m.destinationAddress, m.transactionId
     ])
   }
 

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -18,7 +18,9 @@ const models = {
   TradingTicker: require('./trading_ticker'),
   FundingTicker: require('./funding_ticker'),
   PublicTrade: require('./public_trade'),
-  Candle: require('./candle')
+  Candle: require('./candle'),
+  LedgerEntry: require('./ledger_entry'),
+  Movement: require('./movement')
 }
 
 module.exports = models

--- a/lib/models/ledger_entry.js
+++ b/lib/models/ledger_entry.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const Model = require('../model')
+const BOOL_FIELDS = []
+const FIELDS = {
+  id: 0,
+  currency: 1,
+  mts: 3,
+  amount: 5,
+  balance: 6,
+  description: 8
+}
+
+const FIELD_KEYS = Object.keys(FIELDS)
+
+class LedgerEntry extends Model {
+  constructor (data = {}) {
+    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+
+  static unserialize (arr) {
+    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+}
+
+module.exports = LedgerEntry

--- a/lib/models/movement.js
+++ b/lib/models/movement.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const Model = require('../model')
+const BOOL_FIELDS = []
+const FIELDS = {
+  id: 0,
+  currency: 1,
+  currencyName: 2,
+  mtsStarted: 5,
+  mtsUpdated: 6,
+  status: 9,
+  amount: 12,
+  fees: 13,
+  destinationAddress: 16,
+  transactionId: 20
+}
+
+const FIELD_KEYS = Object.keys(FIELDS)
+
+class Movement extends Model {
+  constructor (data = {}) {
+    super(data, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+
+  static unserialize (arr) {
+    return super.unserialize(arr, FIELDS, BOOL_FIELDS, FIELD_KEYS)
+  }
+}
+
+module.exports = Movement

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -19,7 +19,9 @@ const {
   FundingTicker,
   Wallet,
   Alert,
-  Candle
+  Candle,
+  Movement,
+  LedgerEntry
 } = require('../models')
 
 const BASE_TIMEOUT = 15000
@@ -414,23 +416,37 @@ class RESTv2 {
   }
 
   /**
-   * @param {string} ccy - i.e. ETH
+   * @param {string?} ccy - i.e. ETH
+   * @param {number?} start
+   * @param {number?} end
+   * @param {number?} limit - default 25
    * @param {Method} cb
    * @return {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#movements
    */
-  movements (ccy = 'ETH', cb) {
-    return this._makeAuthRequest(`/auth/r/movements/${ccy}/hist`, {}, cb)
+  movements (ccy, start = null, end = Date.now(), limit = 25, cb) {
+    const url = ccy
+      ? `/auth/r/movements/${ccy}/hist`
+      : '/auth/r/movements/hist'
+
+    return this._makeAuthRequest(url, { start, end, limit }, cb, Movement)
   }
 
   /**
-   * @param {string} ccy - i.e. ETH
+   * @param {string?} ccy - i.e. ETH
+   * @param {number?} start
+   * @param {number?} end
+   * @param {number?} limit - default 25
    * @param {Method} cb
    * @return {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#ledgers
    */
-  ledgers (ccy = 'ETH', cb) {
-    return this._makeAuthRequest(`/auth/r/ledgers/${ccy}/hist`, {}, cb)
+  ledgers (ccy, start = null, end = Date.now(), limit = 25, cb) {
+    const url = ccy
+      ? `/auth/r/ledgers/${ccy}/hist`
+      : '/auth/r/ledgers/hist'
+
+    return this._makeAuthRequest(url, { start, end, limit }, cb, LedgerEntry)
   }
 
   /**

--- a/test/lib/models/ledger_entry.js
+++ b/test/lib/models/ledger_entry.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+'use strict'
+
+const { LedgerEntry } = require('../../../lib/models')
+const testModel = require('../../helpers/test_model')
+
+describe('Ledger entry model', () => {
+  testModel({
+    model: LedgerEntry,
+    orderedFields: [
+      'id', 'currency', null, 'mts', null, 'amount', 'balance', null,
+      'description'
+    ]
+  })
+})

--- a/test/lib/models/movement.js
+++ b/test/lib/models/movement.js
@@ -1,0 +1,16 @@
+/* eslint-env mocha */
+'use strict'
+
+const { Movement } = require('../../../lib/models')
+const testModel = require('../../helpers/test_model')
+
+describe('Movement model', () => {
+  testModel({
+    model: Movement,
+    orderedFields: [
+      'id', 'currency', 'currencyName', null, null, 'mtsStarted', 'mtsUpdated',
+      null, null, 'status', null, null, 'amount', 'fees', null, null,
+      'destinationAddress', null, null, null, 'transactionId'
+    ]
+  })
+})


### PR DESCRIPTION
This PR adds `start`/`end`/`limit` query arg support to the `ledgers()` and `movements()` RESTv2 endpoints. The defaults are an end of `Date.now()` and a limit of `25`.

I've also included the models for ledger entries & movements, courtesy of ezequiel :dancer:.