### PR TITLE
orderbooks: unserialize fix for raw books

### DIFF
--- a/lib/models/order_book.js
+++ b/lib/models/order_book.js
@@ -383,7 +383,7 @@ class OrderBook extends EventEmitter {
    */
   static unserialize (arr, raw = false) {
     if (Array.isArray(arr[0])) {
-      const entries = arr.map(e => OrderBook.unserialize(e))
+      const entries = arr.map(e => OrderBook.unserialize(e, raw))
       const bids = entries.filter(e => e.amount > 0)
       const asks = entries.filter(e => e.amount < 0)
 

--- a/test/lib/models/order_book.js
+++ b/test/lib/models/order_book.js
@@ -653,7 +653,7 @@ describe('OrderBook model', () => {
     assert.deepEqual(ob.asks, [{ price: 200, count: 2, amount: -10 }])
   })
 
-  it('unserialiez: returns map for entries', () => {
+  it('unserialize: returns map for entries', () => {
     const entry = OrderBook.unserialize([150, 0, -1])
 
     assert.deepEqual(entry, {
@@ -661,5 +661,23 @@ describe('OrderBook model', () => {
       count: 0,
       amount: -1
     })
+  })
+
+  it('unserialize: supports raw books', () => {
+    const entry = OrderBook.unserialize([[1337, 150, -1], [1338, 151, 1]], true)
+
+    const exp = {
+      asks: [{
+        orderID: 1337,
+        price: 150,
+        amount: -1
+      }],
+      bids: [{
+        orderID: 1338,
+        price: 151,
+        amount: 1
+      }]
+    }
+    assert.deepEqual(entry, exp)
   })
 })


### PR DESCRIPTION
pass down `raw` option to fix orderID vs. count property in
resulting entry