### PR TITLE
Remove additional throw in _makeAuthRequest

### DIFF
--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -139,7 +139,6 @@ class RESTv2 {
       return res
     }).catch(err => {
       cb(err)
-      throw err
     })
   }
 

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -390,7 +390,11 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-trades-hist
    */
   accountTrades (symbol = 'tBTCUSD', start = null, end = null, limit = null, sort = null, cb) {
-    return this._makeAuthRequest(`/auth/r/trades/${symbol}/hist`, {
+    const url = symbol
+      ? `/auth/r/trades/${symbol}/hist`
+      : '/auth/r/trades/hist'
+
+    return this._makeAuthRequest(url, {
       start, end, limit, sort
     }, cb, Trade)
   }

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -393,9 +393,14 @@ class RESTv2 {
       ? `/auth/r/trades/${symbol}/hist`
       : '/auth/r/trades/hist'
 
-    return this._makeAuthRequest(url, {
-      start, end, limit, sort
-    }, cb, Trade)
+    const query = {}
+
+    if (start !== null) query.start = start
+    if (end !== null) query.end = end
+    if (limit !== null) query.limit = limit
+    if (sort !== null) query.sort = sort
+
+    return this._makeAuthRequest(url, query, cb, Trade)
   }
 
   /**
@@ -459,10 +464,19 @@ class RESTv2 {
    * @return {Promise} p
    * @see https://docs.bitfinex.com/v2/reference#orders-history
    */
-  orderHistory (symbol = 'tBTCUSD', start = null, end = null, limit = null, cb) {
-    return this._makeAuthRequest(`/auth/r/orders/${symbol}/hist`, {
-      start, end, limit
-    }, cb, Order)
+  orderHistory (symbol = 'tBTCUSD', start = null, end = null, limit = null, sort = null, cb) {
+    const url = symbol
+      ? `/auth/r/orders/${symbol}/hist`
+      : '/auth/r/orders/hist'
+
+    const query = {}
+
+    if (start !== null) query.start = start
+    if (end !== null) query.end = end
+    if (limit !== null) query.limit = limit
+    if (sort !== null) query.sort = sort
+
+    return this._makeAuthRequest(url, query, cb, Order)
   }
 
   /**
@@ -476,9 +490,13 @@ class RESTv2 {
    * @see https://docs.bitfinex.com/v2/reference#rest-auth-order-trades
    */
   orderTrades (symbol = 'tBTCUSD', start = null, end = null, limit = null, orderID, cb) {
-    return this._makeAuthRequest(`/auth/r/order/${symbol}:${orderID}/trades`, {
-      start, end, limit
-    }, cb, Trade)
+    const query = {}
+
+    if (start !== null) query.start = start
+    if (end !== null) query.end = end
+    if (limit !== null) query.limit = limit
+
+    return this._makeAuthRequest(`/auth/r/order/${symbol}:${orderID}/trades`, query, cb, Trade)
   }
 
   /**

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -106,8 +106,6 @@ class RESTv2 {
       }
 
       cb(new Error(err))
-
-      throw err // must be caught again
     })
   }
 


### PR DESCRIPTION
My node process always dies in case of an error thrown in the _makeAuthRequest.

I removed the additional throw in that kills the node process because the exception cannot be catched in an easy way.
As far as I know, it is not possible to catch exceptions thrown in JavaScript callbacks (at least, not in any straightforward manner).

In addition, I allowed the accountTrades-call to work without a given symbol.