### PR TITLE
Feature: Socket Manager for Auto Multiplexing

### DIFF
--- a/examples/bfx.js
+++ b/examples/bfx.js
@@ -29,5 +29,5 @@ module.exports.args = {
   apiSecret: API_SECRET,
   wsURL: WS_URL,
   restURL: REST_URL,
-  agent,
+  agent
 }

--- a/examples/bfx.js
+++ b/examples/bfx.js
@@ -24,3 +24,10 @@ const bfx = new BFX({
 })
 
 module.exports = bfx
+module.exports.args = {
+  apiKey: API_KEY,
+  apiSecret: API_SECRET,
+  wsURL: WS_URL,
+  restURL: REST_URL,
+  agent,
+}

--- a/examples/ws2_manager.js
+++ b/examples/ws2_manager.js
@@ -21,7 +21,7 @@ rest.symbolDetails().then(details => {
   const m = new Manager({
     transform: true,
     url: bfx.args.wsURL,
-    ...bfx.args,
+    ...bfx.args
   })
 
   m.on('error', (err) => {

--- a/examples/ws2_manager.js
+++ b/examples/ws2_manager.js
@@ -1,0 +1,59 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const _flatten = require('lodash/flatten')
+const debug = require('debug')('bfx:examples:ws2-manager')
+const bfx = require('./bfx')
+
+const Manager = require('../lib/ws2_manager')
+const rest = bfx.rest(2, { transform: true })
+
+debug('fetching symbol details...')
+
+rest.symbolDetails().then(details => {
+  const symbols = details.map(d => `t${d.pair.toUpperCase()}`)
+  const timeFrames = ['1m', '5m', '30m', '1h', '6h']
+  const keys = _flatten(symbols.map(s => {
+    return timeFrames.map(tf => `trade:${tf}:${s}`)
+  }))
+
+  const m = new Manager({
+    transform: true,
+    url: bfx.args.wsURL,
+    ...bfx.args,
+  })
+
+  m.on('error', (err) => {
+    debug('error: %s', err)
+  })
+
+  m.once('open', () => {
+    debug('open')
+
+    keys.forEach(key => {
+      m.subscribeCandles(key)
+
+      m.onCandle({ key }, (candles) => {
+        debug('recv %d candles on channel %s', candles.length, key)
+
+        /*
+        candles.forEach(c => {
+          debug(`%s %s open: %f, high: %f, low: %f, close: %f, volume: %f`,
+            key, new Date(c.mts).toLocaleTimeString(),
+            c.open, c.high, c.low, c.close, c.volume
+          )
+        })
+        */
+      })
+    })
+
+    setTimeout(() => {
+      debug('num keys: %d', keys.length)
+      debug('num sockets: %d', m.getNumSockets())
+      debug('socket info: %j', m.getSocketInfo())
+    }, 6000)
+  })
+
+  m.openSocket()
+})

--- a/examples/ws2_manager.js
+++ b/examples/ws2_manager.js
@@ -19,7 +19,6 @@ rest.symbolDetails().then(details => {
   }))
 
   const m = new Manager({
-    transform: true,
     url: bfx.args.wsURL,
     ...bfx.args
   })
@@ -33,17 +32,37 @@ rest.symbolDetails().then(details => {
 
     keys.forEach(key => {
       m.subscribeCandles(key)
-
       m.onCandle({ key }, (candles) => {
         debug('recv %d candles on channel %s', candles.length, key)
       })
     })
 
-    setTimeout(() => {
+    symbols.forEach(symbol => {
+      m.subscribeTrades(symbol)
+      m.onTrades({ symbol }, (trades) => {
+        debug('recv %d trades on channel %s', trades.length, symbol)
+      })
+    })
+
+    symbols.forEach(symbol => {
+      m.subscribeTicker(symbol)
+      m.onTicker({ symbol }, (ticker) => {
+        debug('recv ticker on channel %s: %j', symbol, ticker)
+      })
+    })
+
+    symbols.forEach(symbol => {
+      m.subscribeOrderBook(symbol)
+      m.onOrderBook({ symbol }, (update) => {
+        debug('recv book update on channel %s: %j', symbol, update)
+      })
+    })
+
+    setInterval(() => {
       debug('num keys: %d', keys.length)
       debug('num sockets: %d', m.getNumSockets())
       debug('socket info: %j', m.getSocketInfo())
-    }, 6000)
+    }, 5000)
   })
 
   m.openSocket()

--- a/examples/ws2_manager.js
+++ b/examples/ws2_manager.js
@@ -36,15 +36,6 @@ rest.symbolDetails().then(details => {
 
       m.onCandle({ key }, (candles) => {
         debug('recv %d candles on channel %s', candles.length, key)
-
-        /*
-        candles.forEach(c => {
-          debug(`%s %s open: %f, high: %f, low: %f, close: %f, volume: %f`,
-            key, new Date(c.mts).toLocaleTimeString(),
-            c.open, c.high, c.low, c.close, c.volume
-          )
-        })
-        */
       })
     })
 

--- a/lib/transports/rest2.js
+++ b/lib/transports/rest2.js
@@ -483,8 +483,8 @@ class RESTv2 {
    */
   orderHistory (symbol, start = null, end = null, limit = null, cb) {
     const url = !_isEmpty(symbol)
-         ? `/auth/r/orders/${symbol}/hist`
-         : `/auth/r/orders/hist`
+      ? `/auth/r/orders/${symbol}/hist`
+      : `/auth/r/orders/hist`
 
     return this._makeAuthRequest(url, {
       start, end, limit

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -8,6 +8,9 @@ const CbQ = require('cbq')
 const { isFinite } = require('lodash')
 const _Throttle = require('lodash.throttle')
 const _isString = require('lodash/isString')
+const _includes = require('lodash/includes')
+const _pick = require('lodash/pick')
+const _isEqual = require('lodash/isEqual')
 const { genAuthSig, nonce } = require('../util')
 const getMessagePayload = require('../util/ws2')
 
@@ -31,6 +34,7 @@ const {
   FundingTicker
 } = require('../models')
 
+const DATA_CHANNEL_TYPES = ['ticker', 'book', 'candles', 'trades']
 const UCM_NOTIFICATION_TYPE = 'ucm-notify-ui'
 const WS_URL = 'wss://api.bitfinex.com/ws/2'
 const MAX_CALC_OPS = 8
@@ -124,6 +128,36 @@ class WSv2 extends EventEmitter {
     this._onWSMessage = this._onWSMessage.bind(this)
     this._triggerPacketWD = this._triggerPacketWD.bind(this)
     this._sendCalc = _Throttle(this._sendCalc.bind(this), 1000 / MAX_CALC_OPS)
+  }
+
+  setAPICredentials (apiKey, apiSecret) {
+    this._apiKey = apiKey
+    this._apiSecret = apiSecret
+  }
+
+  getDataChannelCount () {
+    return Object
+      .values(this._channelMap)
+      .filter(c => _includes(DATA_CHANNEL_TYPES, c.channel))
+      .length
+  }
+
+  hasChannel (chanId) {
+    return _includes(Object.keys(this._channelMap), chanId)
+  }
+
+  getDataChannelId (type, filter) {
+    return Object
+      .keys(this._channelMap)
+      .find(cid => {
+        const c = this._channelMap[cid]
+        const fv = _pick(c, Object.keys(filter))
+        return _isEqual(fv, filter)
+      })
+  }
+
+  hasDataChannel (type, filter) {
+    return !!this.getDataChannelId(type, filter)
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -75,6 +75,7 @@ class WSv2 extends EventEmitter {
   constructor (opts = { apiKey: '', apiSecret: '', url: WS_URL }) {
     super()
 
+    this.setMaxListeners(1000)
     this._apiKey = opts.apiKey || ''
     this._apiSecret = opts.apiSecret || ''
     this._agent = opts.agent

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -26,6 +26,7 @@ module.exports = class WS2Manager extends EventEmitter {
   constructor (socketArgs, authArgs = { calc: 0, dms: 0 }) {
     super()
 
+    this.setMaxListeners(1000)
     this._socketArgs = socketArgs || {}
     this._authArgs = authArgs
     this._sockets = []

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -78,7 +78,7 @@ module.exports = class WS2Manager extends EventEmitter {
    * @param {Object?} args.calc - default 0
    * @param {Object?} args.dms - dead man switch, active 4
    */
-  auth ({ apiKey, apiSecret, calc = 0, dms = 0 }) {
+  auth ({ apiKey, apiSecret, calc = 0, dms = 0 } = {}) {
     if (this._socketArgs.apiKey || this._socketArgs.apiSecret) {
       debug('error: auth credentials already provided! refusing auth')
       return

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -73,16 +73,16 @@ module.exports = class WS2Manager extends EventEmitter {
     const wsState = {
       pendingSubscriptions: [],
       pendingUnsubscriptions: [],
-      ws,
+      ws
     }
 
     ws.once('open', () => debug('socket connection opened'))
     ws.on('open', () => this.emit('open', ws))
-    ws.on('message', (msg) => this.emit('message', msg, ws))
+    ws.on('message', (msg = {}) => this.emit('message', msg, ws))
     ws.on('error', (error) => this.emit('error', error, ws))
     ws.on('auth', () => this.emit('auth', ws))
     ws.on('close', () => this.emit('close', ws))
-    ws.on('subscribed', (msg) => {
+    ws.on('subscribed', (msg = {}) => {
       const i = wsState.pendingSubscriptions.find(sub => {
         const fv = _pick(msg, Object.keys(sub[1]))
 
@@ -98,9 +98,10 @@ module.exports = class WS2Manager extends EventEmitter {
       }
 
       wsState.pendingSubscriptions.splice(i, 1)
+      this.emit('subscribed', msg)
     })
 
-    ws.on('unsubscribed', (msg) => {
+    ws.on('unsubscribed', (msg = {}) => {
       const { chanId } = msg
       const i = wsState.pendingUnsubscriptions.find(cid => (
         cid === chanId
@@ -112,6 +113,7 @@ module.exports = class WS2Manager extends EventEmitter {
       }
 
       wsState.pendingUnsubscriptions.splice(i, 1)
+      this.emit('unsubscribed', msg)
     })
 
     if (apiKey && apiSecret) { // auto-auth
@@ -136,7 +138,7 @@ module.exports = class WS2Manager extends EventEmitter {
 
   getSocketWithDataChannel (type, filter) {
     return this._sockets.find(s => {
-      const subI = s.pendingSubscriptions.find(s => (
+      const subI = s.pendingSubscriptions.findIndex(s => (
         s[0] === type && _isEqual(s[1], filter)
       ))
 
@@ -212,7 +214,7 @@ module.exports = class WS2Manager extends EventEmitter {
     return this.subscribe('candles', key, { key })
   }
 
-  onCandle({ key, cbGID }, cb) {
+  onCandle ({ key, cbGID }, cb) {
     const s = this.getSocketWithDataChannel('candles', { key })
     s.ws.onCandle({ key, cbGID }, cb)
   }
@@ -231,5 +233,4 @@ module.exports = class WS2Manager extends EventEmitter {
     const s = this.getSocketWithDataChannel('ticker', { symbol })
     s.ws.onTicker({ symbol, cbGID }, cb)
   }
-
 }

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -9,7 +9,13 @@ const WSv2 = require('./transports/ws2')
 
 const DATA_CHANNEL_LIMIT = 50
 
-// Auto-authenticates if apikey/secret are provided
+/**
+ * Provides a wrapper around the WSv2 class, opening new sockets when a
+ * subscription would push a single socket over the data channel limit.
+ *
+ * For more complex operations, grab a socket reference with getSocket() or
+ * one of getFreeSocket() & co.
+ */
 module.exports = class WS2Manager extends EventEmitter {
   /**
    * @param {Object} socketArgs - passed to WSv2 constructors
@@ -25,6 +31,10 @@ module.exports = class WS2Manager extends EventEmitter {
     this._sockets = []
   }
 
+  /**
+   * @param {Object} s - socket state
+   * @return {number} count - # of subscribed/pending data channels
+   */
   static getDataChannelCount (s) {
     let count = s.ws.getDataChannelCount()
 
@@ -34,20 +44,40 @@ module.exports = class WS2Manager extends EventEmitter {
     return count
   }
 
+  /**
+   * @return {number} n
+   */
   getNumSockets () {
     return this._sockets.length
   }
 
+  /**
+   * @param {number} i
+   * @return {Object} state
+   */
   getSocket (i) {
     return this._sockets[i]
   }
 
+  /**
+   * Returns an object which can be logged to inspect the socket pool
+   */
   getSocketInfo () {
     return this._sockets.map(s => ({
       nChannels: WS2Manager.getDataChannelCount(s)
     }))
   }
 
+  /**
+   * Authenticates all existing & future sockets with the provided credentials.
+   * Does nothing if an apiKey/apiSecret pair are already known.
+   *
+   * @param {Object} args
+   * @param {Object?} args.apiKey - saved if not already provided
+   * @param {Object?} args.apiSecret - saved if not already provided
+   * @param {Object?} args.calc - default 0
+   * @param {Object?} args.dms - dead man switch, active 4
+   */
   auth ({ apiKey, apiSecret, calc = 0, dms = 0 }) {
     if (this._socketArgs.apiKey || this._socketArgs.apiSecret) {
       debug('error: auth credentials already provided! refusing auth')
@@ -66,6 +96,13 @@ module.exports = class WS2Manager extends EventEmitter {
     })
   }
 
+  /**
+   * Creates a new socket/state instance and adds it to the internal pool. Binds
+   * event listeners to forward via our own event emitter, and to manage pending
+   * subs/unsubs.
+   *
+   * @return {Object} state
+   */
   openSocket () {
     const { apiKey, apiSecret } = this._socketArgs
     const { calc, dms } = this._authArgs
@@ -130,12 +167,26 @@ module.exports = class WS2Manager extends EventEmitter {
     return wsState
   }
 
+  /**
+   * Returns the first socket that has less active/pending channels than the
+   * DATA_CHANNEL_LIMIT
+   *
+   * @return {Object} state - undefined if none found
+   */
   getFreeDataSocket () {
     return this._sockets.find(s => (
       WS2Manager.getDataChannelCount(s) < DATA_CHANNEL_LIMIT
     ))
   }
 
+  /**
+   * Returns the first socket that is subscribed/pending sub to the specified
+   * channel.
+   *
+   * @param {string} type - i.e. 'book'
+   * @param {Object} filter - i.e. { symbol: 'tBTCUSD', prec: 'R0' }
+   * @return {Object} wsState - undefined if not found
+   */
   getSocketWithDataChannel (type, filter) {
     return this._sockets.find(s => {
       const subI = s.pendingSubscriptions.findIndex(s => (
@@ -157,7 +208,12 @@ module.exports = class WS2Manager extends EventEmitter {
     })
   }
 
-  // NOTE: Cannot filter against pending subscriptions, due to unknown chanId
+  /**
+   * NOTE: Cannot filter against pending subscriptions, due to unknown chanId
+   *
+   * @param {number} chanId
+   * @return {Object} wsState - undefined if not found
+   */
   getSocketWithChannel (chanId) {
     return this._sockets.find(s => {
       return (
@@ -167,6 +223,14 @@ module.exports = class WS2Manager extends EventEmitter {
     })
   }
 
+  /**
+   * Subscribes a free data socket if available to the specified channel, or
+   * opens a new socket & subs if needed.
+   *
+   * @param {string} type - i.e. 'book'
+   * @param {string} ident - i.e. 'tBTCUSD'
+   * @param {Object} filter - i.e. { symbol: 'tBTCUSD', prec: 'R0' }
+   */
   subscribe (type, ident, filter) {
     let s = this.getFreeDataSocket()
     const doSub = () => {
@@ -186,6 +250,12 @@ module.exports = class WS2Manager extends EventEmitter {
     s.pendingSubscriptions.push([type, filter])
   }
 
+  /**
+   * Unsubscribes the first socket w/ the specified channel. Does nothing if no
+   * such socket is found.
+   *
+   * @param {number} chanId
+   */
   unsubscribe (chanId) {
     const s = this.getSocketWithChannel(chanId)
 
@@ -198,14 +268,25 @@ module.exports = class WS2Manager extends EventEmitter {
     s.pendingUnsubscriptions.push(chanId)
   }
 
+  /**
+   * @param {string} symbol
+   */
   subscribeTicker (symbol) {
     return this.subscribe('ticker', symbol, { symbol })
   }
 
+  /**
+   * @param {string} symbol
+   */
   subscribeTrades (symbol) {
     return this.subscribe('trades', symbol, { symbol })
   }
 
+  /**
+   * @param {string} symbol
+   * @param {string} prec
+   * @param {string} len
+   */
   subscribeOrderBook (symbol, prec = 'P0', len = '25') {
     const filter = {}
 
@@ -216,15 +297,34 @@ module.exports = class WS2Manager extends EventEmitter {
     return this.subscribe('book', symbol, filter)
   }
 
+  /**
+   * @param {string} key
+   */
   subscribeCandles (key) {
     return this.subscribe('candles', key, { key })
   }
 
+  /**
+   * @param {Object} opts
+   * @param {string} opts.key - candle set key, i.e. trade:30m:tBTCUSD
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-candle
+   */
   onCandle ({ key, cbGID }, cb) {
     const s = this.getSocketWithDataChannel('candles', { key })
     s.ws.onCandle({ key, cbGID }, cb)
   }
 
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.prec
+   * @param {string} opts.len
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-order-books
+   */
   onOrderBook ({ symbol, prec = 'P0', len = '25', cbGID }, cb) {
     const filter = {}
 
@@ -236,11 +336,25 @@ module.exports = class WS2Manager extends EventEmitter {
     s.ws.onOrderBook({ cbGID, ...filter }, cb)
   }
 
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-trades
+   */
   onTrades ({ symbol, cbGID }, cb) {
     const s = this.getSocketWithDataChannel('trades', { symbol })
     s.ws.onTrades({ symbol, cbGID }, cb)
   }
 
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-ticker
+   */
   onTicker ({ symbol = '', cbGID } = {}, cb) {
     const s = this.getSocketWithDataChannel('ticker', { symbol })
     s.ws.onTicker({ symbol, cbGID }, cb)

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -144,7 +144,7 @@ module.exports = class WS2Manager extends EventEmitter {
       this.emit('unsubscribed', msg)
 
       const { chanId } = msg
-      const i = wsState.pendingUnsubscriptions.find(cid => (
+      const i = wsState.pendingUnsubscriptions.findIndex(cid => (
         cid === chanId
       ))
 

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -214,4 +214,20 @@ module.exports = class WS2Manager extends EventEmitter {
     const s = this.getSocketWithDataChannel('candles', { key })
     s.ws.onCandle({ key, cbGID }, cb)
   }
+
+  onOrderBook ({ symbol, prec, len, cbGID }, cb) {
+    const s = this.getSocketWithDataChannel('book', { symbol, prec, len })
+    s.ws.onOrderBook({ symbol, prec, len, cbGID }, cb)
+  }
+
+  onTrades ({ pair, cbGID }, cb) {
+    const s = this.getSocketWithDataChannel('trades', { pair })
+    s.ws.onTrades({ pair, cbGID }, cb)
+  }
+
+  onTicker ({ symbol = '', cbGID } = {}, cb) {
+    const s = this.getSocketWithDataChannel('ticker', { symbol })
+    s.ws.onTicker({ symbol, cbGID }, cb)
+  }
+
 }

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -207,7 +207,13 @@ module.exports = class WS2Manager extends EventEmitter {
   }
 
   subscribeOrderBook (symbol, prec = 'P0', len = '25') {
-    return this.subscribe('book', symbol, { symbol, len, prec })
+    const filter = {}
+
+    if (symbol) filter.symbol = symbol
+    if (prec) filter.prec = prec
+    if (len) filter.len = len
+
+    return this.subscribe('book', symbol, filter)
   }
 
   subscribeCandles (key) {
@@ -219,14 +225,20 @@ module.exports = class WS2Manager extends EventEmitter {
     s.ws.onCandle({ key, cbGID }, cb)
   }
 
-  onOrderBook ({ symbol, prec, len, cbGID }, cb) {
-    const s = this.getSocketWithDataChannel('book', { symbol, prec, len })
-    s.ws.onOrderBook({ symbol, prec, len, cbGID }, cb)
+  onOrderBook ({ symbol, prec = 'P0', len = '25', cbGID }, cb) {
+    const filter = {}
+
+    if (symbol) filter.symbol = symbol
+    if (prec) filter.prec = prec
+    if (len) filter.len = len
+
+    const s = this.getSocketWithDataChannel('book', filter)
+    s.ws.onOrderBook({ cbGID, ...filter }, cb)
   }
 
-  onTrades ({ pair, cbGID }, cb) {
-    const s = this.getSocketWithDataChannel('trades', { pair })
-    s.ws.onTrades({ pair, cbGID }, cb)
+  onTrades ({ symbol, cbGID }, cb) {
+    const s = this.getSocketWithDataChannel('trades', { symbol })
+    s.ws.onTrades({ symbol, cbGID }, cb)
   }
 
   onTicker ({ symbol = '', cbGID } = {}, cb) {

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -121,6 +121,8 @@ module.exports = class WS2Manager extends EventEmitter {
     ws.on('auth', () => this.emit('auth', ws))
     ws.on('close', () => this.emit('close', ws))
     ws.on('subscribed', (msg = {}) => {
+      this.emit('subscribed', msg)
+
       const i = wsState.pendingSubscriptions.find(sub => {
         const fv = _pick(msg, Object.keys(sub[1]))
 
@@ -136,10 +138,11 @@ module.exports = class WS2Manager extends EventEmitter {
       }
 
       wsState.pendingSubscriptions.splice(i, 1)
-      this.emit('subscribed', msg)
     })
 
     ws.on('unsubscribed', (msg = {}) => {
+      this.emit('unsubscribed', msg)
+
       const { chanId } = msg
       const i = wsState.pendingUnsubscriptions.find(cid => (
         cid === chanId
@@ -151,7 +154,6 @@ module.exports = class WS2Manager extends EventEmitter {
       }
 
       wsState.pendingUnsubscriptions.splice(i, 1)
-      this.emit('unsubscribed', msg)
     })
 
     if (apiKey && apiSecret) { // auto-auth

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -59,8 +59,10 @@ module.exports = class WS2Manager extends EventEmitter {
     this._authArgs = { calc, dms }
 
     this._sockets.forEach(s => {
-      s.setAuthCredentials(apiKey, apiSecret)
-      s.auth({ calc, dms })
+      if (!s.ws.isAuthenticated()) {
+        s.ws.setAuthCredentials(apiKey, apiSecret)
+        s.ws.auth({ calc, dms })
+      }
     })
   }
 

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -1,0 +1,217 @@
+'use strict'
+
+const { EventEmitter } = require('events')
+const debug = require('debug')('bitfinex:ws2_manager')
+const _isEqual = require('lodash/isEqual')
+const _includes = require('lodash/includes')
+const _pick = require('lodash/pick')
+const WSv2 = require('./transports/ws2')
+
+const DATA_CHANNEL_LIMIT = 50
+
+// Auto-authenticates if apikey/secret are provided
+module.exports = class WS2Manager extends EventEmitter {
+  /**
+   * @param {Object} socketArgs - passed to WSv2 constructors
+   * @param {Object} authArgs - cached for all internal socket auth() calls
+   * @param {Object} authArgs.calc - default 0
+   * @param {Object} authArgs.dms - default 0
+   */
+  constructor (socketArgs, authArgs = { calc: 0, dms: 0 }) {
+    super()
+
+    this._socketArgs = socketArgs || {}
+    this._authArgs = authArgs
+    this._sockets = []
+  }
+
+  static getDataChannelCount (s) {
+    let count = s.ws.getDataChannelCount()
+
+    count += s.pendingSubscriptions.length
+    count -= s.pendingUnsubscriptions.length
+
+    return count
+  }
+
+  getNumSockets () {
+    return this._sockets.length
+  }
+
+  getSocket (i) {
+    return this._sockets[i]
+  }
+
+  getSocketInfo () {
+    return this._sockets.map(s => ({
+      nChannels: WS2Manager.getDataChannelCount(s)
+    }))
+  }
+
+  auth ({ apiKey, apiSecret, calc = 0, dms = 0 }) {
+    if (this._socketArgs.apiKey || this._socketArgs.apiSecret) {
+      debug('error: auth credentials already provided! refusing auth')
+      return
+    }
+
+    this._socketArgs.apiKey = apiKey
+    this._socketArgs.apiSecret = apiSecret
+    this._authArgs = { calc, dms }
+
+    this._sockets.forEach(s => {
+      s.setAuthCredentials(apiKey, apiSecret)
+      s.auth({ calc, dms })
+    })
+  }
+
+  openSocket () {
+    const { apiKey, apiSecret } = this._socketArgs
+    const { calc, dms } = this._authArgs
+    const ws = new WSv2(this._socketArgs)
+    const wsState = {
+      pendingSubscriptions: [],
+      pendingUnsubscriptions: [],
+      ws,
+    }
+
+    ws.once('open', () => debug('socket connection opened'))
+    ws.on('open', () => this.emit('open', ws))
+    ws.on('message', (msg) => this.emit('message', msg, ws))
+    ws.on('error', (error) => this.emit('error', error, ws))
+    ws.on('auth', () => this.emit('auth', ws))
+    ws.on('close', () => this.emit('close', ws))
+    ws.on('subscribed', (msg) => {
+      const i = wsState.pendingSubscriptions.find(sub => {
+        const fv = _pick(msg, Object.keys(sub[1]))
+
+        return (
+          (sub[0] === msg.channel) &&
+          _isEqual(fv, sub[1])
+        )
+      })
+
+      if (i === -1) {
+        debug('error removing pending sub: %j', msg)
+        return
+      }
+
+      wsState.pendingSubscriptions.splice(i, 1)
+    })
+
+    ws.on('unsubscribed', (msg) => {
+      const { chanId } = msg
+      const i = wsState.pendingUnsubscriptions.find(cid => (
+        cid === chanId
+      ))
+
+      if (i === -1) {
+        debug('error removing pending unsub: %j', msg)
+        return
+      }
+
+      wsState.pendingUnsubscriptions.splice(i, 1)
+    })
+
+    if (apiKey && apiSecret) { // auto-auth
+      ws.once('open', () => {
+        debug('authenticating socket...')
+
+        ws.auth(calc, dms)
+        ws.once('auth', () => debug('socket authenticated'))
+      })
+    }
+
+    ws.open()
+    this._sockets.push(wsState)
+    return wsState
+  }
+
+  getFreeDataSocket () {
+    return this._sockets.find(s => (
+      WS2Manager.getDataChannelCount(s) < DATA_CHANNEL_LIMIT
+    ))
+  }
+
+  getSocketWithDataChannel (type, filter) {
+    return this._sockets.find(s => {
+      const subI = s.pendingSubscriptions.find(s => (
+        s[0] === type && _isEqual(s[1], filter)
+      ))
+
+      if (subI !== -1) {
+        return true
+      }
+
+      // Confirm unsub is not pending
+      const cid = s.ws.getDataChannelId(type, filter)
+
+      if (!cid) {
+        return false
+      }
+
+      return cid && !_includes(s.pendingUnsubscriptions, cid)
+    })
+  }
+
+  // NOTE: Cannot filter against pending subscriptions, due to unknown chanId
+  getSocketWithChannel (chanId) {
+    return this._sockets.find(s => {
+      return (
+        s.ws.hasChannel(chanId) &&
+        !_includes(s.pendingUnsubscriptions, chanId)
+      )
+    })
+  }
+
+  subscribe (type, ident, filter) {
+    let s = this.getFreeDataSocket()
+    const doSub = () => {
+      s.ws.managedSubscribe(type, ident, filter)
+    }
+
+    if (!s) {
+      s = this.openSocket()
+    }
+
+    if (!s.ws.isOpen()) {
+      s.ws.once('open', doSub)
+    } else {
+      doSub()
+    }
+
+    s.pendingSubscriptions.push([type, filter])
+  }
+
+  unsubscribe (chanId) {
+    const s = this.getSocketWithChannel(chanId)
+
+    if (!s) {
+      debug('cannot unsub from unknown channel: %d', chanId)
+      return
+    }
+
+    s.ws.unsubscribe(chanId)
+    s.pendingUnsubscriptions.push(chanId)
+  }
+
+  subscribeTicker (symbol) {
+    return this.subscribe('ticker', symbol, { symbol })
+  }
+
+  subscribeTrades (symbol) {
+    return this.subscribe('trades', symbol, { symbol })
+  }
+
+  subscribeOrderBook (symbol, prec = 'P0', len = '25') {
+    return this.subscribe('book', symbol, { symbol, len, prec })
+  }
+
+  subscribeCandles (key) {
+    return this.subscribe('candles', key, { key })
+  }
+
+  onCandle({ key, cbGID }, cb) {
+    const s = this.getSocketWithDataChannel('candles', { key })
+    s.ws.onCandle({ key, cbGID }, cb)
+  }
+}

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -102,6 +102,21 @@ describe('WS2Manager', () => {
 
       assert.equal(s.pendingUnsubscriptions.length, 0)
     })
+
+    it('binds \'subscribed\' listener to remove channel from pending subs', () => {
+      const m = new WS2Manager()
+      const s = m.openSocket()
+
+      s.pendingSubscriptions.push(['book', { symbol: 'tBTCUSD', prec: 'R0' }])
+      s.ws.emit('subscribed', {
+        channel: 'book',
+        symbol: 'tBTCUSD',
+        prec: 'R0',
+        len: '25'
+      })
+
+      assert.equal(s.pendingSubscriptions.length, 0)
+    })
   })
 
   describe('getFreeDataSocket', () => {

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -92,6 +92,16 @@ describe('WS2Manager', () => {
       const s = m.openSocket()
       assert.deepEqual(m._sockets[0], s)
     })
+
+    it('binds \'unsubscribe\' listener to remove channel from pending unsubs', () => {
+      const m = new WS2Manager()
+      const s = m.openSocket()
+
+      s.pendingUnsubscriptions.push(42)
+      s.ws.emit('unsubscribed', { chanId: 42 })
+
+      assert.equal(s.pendingUnsubscriptions.length, 0)
+    })
   })
 
   describe('getFreeDataSocket', () => {

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -1,0 +1,323 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const WS2Manager = require('../../lib/ws2_manager')
+const WSv2 = require('../../lib/transports/ws2')
+
+describe('WS2Manager', () => {
+  describe('getDataChannelCount', () => {
+    it('takes pending subs & unsubs into account', () => {
+      const s = {
+        ws: new WSv2(),
+        pendingSubscriptions: [['book', {}]],
+        pendingUnsubscriptions: []
+      }
+
+      s.ws._channelMap = {
+        0: { channel: 'trades' },
+        1: { channel: 'candles', key: 'test' },
+        2: { channel: 'auth' }
+      }
+
+      const count = WS2Manager.getDataChannelCount(s)
+
+      assert.equal(s.ws.getDataChannelCount(), 2)
+      assert.equal(count, 3)
+    })
+  })
+
+  describe('auth', () => {
+    it('does nothing if api key/secret are already provided', () => {
+      const m = new WS2Manager({ apiKey: 'x', apiSecret: 'x' })
+
+      m.auth({ apiKey: '42', apiSecret: '43' })
+      assert.equal(m._socketArgs.apiKey, 'x')
+      assert.equal(m._socketArgs.apiSecret, 'x')
+    })
+
+    it('saves auth args', () => {
+      const m = new WS2Manager()
+
+      m.auth({ calc: 1, dms: 4 })
+      assert.equal(m._authArgs.calc, 1)
+      assert.equal(m._authArgs.dms, 4)
+    })
+
+    it('calls auth on existing unauthenticated sockets', (done) => {
+      let cred = false
+      const m = new WS2Manager()
+
+      m._sockets = [{
+        ws: {
+          isAuthenticated: () => false,
+          setAuthCredentials: (key, secret) => { cred = `${key}:${secret}` },
+          auth: ({ calc, dms }) => {
+            assert.equal(calc, 1)
+            assert.equal(dms, 4)
+            assert.equal(cred, '41:42')
+            done()
+          }
+        }
+      }]
+
+      m.auth({ apiKey: '41', apiSecret: '42', calc: 1, dms: 4 })
+    })
+  })
+
+  describe('openSocket', () => {
+    it('binds listeners to forward events', () => {
+      const heardEvents = {}
+      const events = [
+        'open', 'message', 'auth', 'error', 'close', 'subscribed',
+        'unsubscribed'
+      ]
+
+      const m = new WS2Manager()
+      const s = m.openSocket()
+      const { ws } = s
+
+      events.forEach(e => {
+        m.on(e, () => { heardEvents[e] = true })
+      })
+
+      events.forEach(e => ws.emit(e))
+      events.forEach(e => {
+        assert(heardEvents[e])
+      })
+    })
+
+    it('saves socket state', () => {
+      const m = new WS2Manager()
+      const s = m.openSocket()
+      assert.deepEqual(m._sockets[0], s)
+    })
+  })
+
+  describe('getFreeDataSocket', () => {
+    it('returns the first socket below the data channel limit', () => {
+      const m = new WS2Manager()
+
+      m._sockets[0] = {
+        ws: { getDataChannelCount: () => 35 },
+        pendingSubscriptions: new Array(30),
+        pendingUnsubscriptions: new Array(10)
+      }
+
+      m._sockets[1] = {
+        ws: { getDataChannelCount: () => 5 },
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: []
+      }
+
+      const s = m.getFreeDataSocket()
+      assert.deepEqual(s, m._sockets[1])
+    })
+  })
+
+  describe('getSocketWithDataChannel', () => {
+    it('returns socket subscribed to specified channel/filter pair', () => {
+      const m = new WS2Manager()
+      m._sockets[0] = {
+        ws: {},
+        pendingSubscriptions: [['candles', { key: 'test' }]],
+        pendingUnsubscriptions: []
+      }
+
+      let s = m.getSocketWithDataChannel('candles', { key: 'test' })
+      assert.deepEqual(s, m._sockets[0])
+
+      /// /
+      m._sockets[0] = {
+        ws: { getDataChannelId: () => false },
+        pendingSubscriptions: [['auth', {}]],
+        pendingUnsubscriptions: []
+      }
+
+      s = m.getSocketWithDataChannel('candles', { key: 'test' })
+      assert(!s)
+
+      /// /
+      m._sockets[0] = {
+        ws: {
+          getDataChannelId: (type, filter) => {
+            assert.equal(type, 'candles')
+            assert.deepEqual(filter, { key: 'test' })
+            return 1
+          }
+        },
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: []
+      }
+
+      s = m.getSocketWithDataChannel('candles', { key: 'test' })
+      assert.deepEqual(s, m._sockets[0])
+
+      /// /
+      m._sockets[0] = {
+        ws: {
+          getDataChannelId: (type, filter) => {
+            assert.equal(type, 'candles')
+            assert.deepEqual(filter, { key: 'test' })
+            return 1
+          }
+        },
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: [1]
+      }
+
+      s = m.getSocketWithDataChannel('candles', { key: 'test' })
+      assert(!s)
+    })
+  })
+
+  describe('getSocketWithChannel', () => {
+    it('returns correct socket', () => {
+      const m = new WS2Manager()
+      m._sockets[0] = {
+        pendingUnsubscriptions: [],
+        ws: {
+          hasChannel: (id) => {
+            return id === 42
+          }
+        }
+      }
+
+      let s = m.getSocketWithChannel(42)
+      assert.deepEqual(s, m._sockets[0])
+
+      /// /
+      m._sockets[0] = {
+        pendingUnsubscriptions: [42],
+        ws: {
+          hasChannel: (id) => {
+            return id === 42
+          }
+        }
+      }
+
+      s = m.getSocketWithChannel(42)
+      assert(!s)
+    })
+  })
+
+  describe('subscribe', () => {
+    it('delays sub for unopened sockets', () => {
+      const m = new WS2Manager()
+      let onceOpenCalled = false
+
+      m._sockets[0] = {
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: [],
+        ws: {
+          getDataChannelCount: () => 0,
+          managedSubscribe: () => assert(false),
+          isOpen: () => false,
+          once: (eName) => {
+            assert.equal(eName, 'open')
+            onceOpenCalled = true
+          }
+        }
+      }
+
+      m.subscribe('candles', 'test', { key: 'test' })
+      assert(onceOpenCalled)
+    })
+
+    it('saves pending sub', () => {
+      const m = new WS2Manager()
+      m._sockets[0] = {
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: [],
+        ws: {
+          getDataChannelCount: () => 0,
+          managedSubscribe: () => {},
+          isOpen: () => true
+        }
+      }
+
+      m.subscribe('candles', 'test', { key: 'test' })
+      assert.deepEqual(m._sockets[0].pendingSubscriptions, [
+        ['candles', { key: 'test' }]
+      ])
+    })
+
+    it('opens a new socket if no sockets are available', () => {
+      const m = new WS2Manager()
+      let openCalled = false
+
+      m.openSocket = () => {
+        openCalled = true
+
+        return {
+          pendingSubscriptions: [],
+          ws: {
+            once: () => {},
+            isOpen: () => false // to avoid managed sub
+          }
+        }
+      }
+
+      m.subscribe('candles', 'test', { key: 'test' })
+      assert(openCalled)
+    })
+
+    it('opens a new socket if no sockets are below data limit', () => {
+      const m = new WS2Manager()
+      let openCalled = false
+
+      m._sockets[0] = {
+        pendingSubscriptions: [],
+        pendingUnsubscriptions: [],
+        ws: {
+          getDataChannelCount: () => 55
+        }
+      }
+
+      m.openSocket = () => {
+        openCalled = true
+
+        const state = {
+          pendingSubscriptions: [],
+          ws: {
+            once: () => {},
+            isOpen: () => false // to avoid managed sub
+          }
+        }
+
+        m._sockets.push(state)
+        return state
+      }
+
+      m.subscribe('candles', 'test', { key: 'test' })
+
+      assert(openCalled)
+      assert.equal(m._sockets.length, 2)
+    })
+  })
+
+  describe('unsubscribe', () => {
+    it('saves pending unsub & calls unsub on socket', () => {
+      const m = new WS2Manager()
+      let unsubCalled = false
+
+      m._sockets[0] = {
+        pendingUnsubscriptions: [],
+        ws: {
+          unsubscribe: (cid) => {
+            assert.equal(cid, 42)
+            unsubCalled = true
+          },
+
+          hasChannel: (cid) => {
+            return cid === 42
+          }
+        }
+      }
+
+      m.unsubscribe(42)
+      assert.deepEqual(m._sockets[0].pendingUnsubscriptions, [42])
+      assert(unsubCalled)
+    })
+  })
+})

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -93,7 +93,7 @@ describe('WS2Manager', () => {
       assert.deepEqual(m._sockets[0], s)
     })
 
-    it('binds \'unsubscribe\' listener to remove channel from pending unsubs', () => {
+    it('binds \'unsubscribed\' listener to remove channel from pending unsubs', () => {
       const m = new WS2Manager()
       const s = m.openSocket()
 


### PR DESCRIPTION
Closes #369 

Adds a `WS2Manager` class which wraps `WSv2`, automatically opening new socket connections when a `subscribe()` call would exceed the new limit of 50 data channels per connection.

The new manager should be used when subscribing to `'trades'`, `'candles'`, `'ticker'`, or `'book'` channels. Otherwise, call `getSocket(i)` to access an underlying socket `WSv2` class instance.

A few high level helpers are provided on `WS2Manager` for requesting sockets suitable for `subscribe()` calls:
* `getFreeDataSocket()`
* `getSocketWithDataChannel()`
* `getSocketWithChannel()`

The manager takes `(socketArgs, authArgs)` params which are shared between all internal sockets; if authentication credentials are provided to the constructor, or later supplied via a call to `.auth({ ... })`, all existing sockets & all future sockets are authenticated with those credentials.

Example usage:
```js
const Manager = require('../lib/ws2_manager')
const rest = bfx.rest(2, { transform: true })

debug('fetching symbol details...')

rest.symbolDetails().then(details => {
  const symbols = details.map(d => `t${d.pair.toUpperCase()}`)
  const timeFrames = ['1m', '5m', '30m', '1h', '6h']
  const keys = _flatten(symbols.map(s => {
    return timeFrames.map(tf => `trade:${tf}:${s}`)
  }))

  const m = new Manager({
    transform: true,
    url: bfx.args.wsURL,
    ...bfx.args,
  })

  m.on('error', (err) => {
    debug('error: %s', err)
  })

  m.once('open', () => {
    debug('open')

    keys.forEach(key => {
      m.subscribeCandles(key)

      m.onCandle({ key }, (candles) => {
        debug('recv %d candles on channel %s', candles.length, key)
      })
    })

    setTimeout(() => {
      debug('num keys: %d', keys.length)
      debug('num sockets: %d', m.getNumSockets())
      debug('socket info: %j', m.getSocketInfo())
    }, 6000)
  })

  m.openSocket()
})
```