### PR TITLE
fix event onTrades not fired

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -682,7 +682,7 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleTradeMessage (msg, chanData) {
-    const eventName = _isString(msg[1]) ? msg[1] : 'trades'
+    const eventName = _isString(msg[1]) && msg[1] !== 'te' ? msg[1] : 'trades'
     let payload = getMessagePayload(msg)
 
     if (!Array.isArray(payload[0])) {


### PR DESCRIPTION
Since commit 46af2116fbc46a7aea4f51d053369ca620bee1ef, the `onTrades` function is no longer called.