### PR TITLE
Refactor: Split up trades listeners between public & private trades

### DIFF
--- a/examples/ws2/trades.js
+++ b/examples/ws2/trades.js
@@ -9,19 +9,24 @@ const ws = bfx.ws(2)
 
 ws.on('open', () => {
   debug('open')
-  ws.subscribeTrades('tBTCUSD')
+  ws.subscribeTrades('tEOSUSD')
+  ws.auth()
 })
 
-ws.onTradeEntry({ pair: 'BTCUSD' }, (trade) => {
+ws.onTradeEntry({ pair: 'EOSUSD' }, (trade) => {
   debug('te: %j', trade)
 })
 
-ws.onTradeUpdate({ pair: 'BTCUSD' }, (trade) => {
-  debug('tu: %j', trade)
+ws.onTrades({ pair: 'EOSUSD' }, (trades) => {
+  debug('trades: %j', trades)
 })
 
-ws.onTrades({ pair: 'BTCUSD' }, (trades) => {
-  debug('trades: %j', trades)
+ws.onAccountTradeEntry({ symbol: 'tEOSUSD' }, (trade) => {
+  debug('account te: %j', trade)
+})
+
+ws.onAccountTradeUpdate({ symbol: 'tEOSUSD' }, (trade) => {
+  debug('account tu: %j', trade)
 })
 
 ws.open()

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -682,15 +682,14 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleTradeMessage (msg, chanData) {
-    const eventName = _isString(msg[1]) ? msg[1] : 'trades'
+    const eventName = msg[1] === 'te' ? 'trade-entry' : 'trades'
     let payload = getMessagePayload(msg)
 
     if (!Array.isArray(payload[0])) {
       payload = [payload]
     }
 
-    const model = msg[0] === 0 ? Trade : PublicTrade // auth trades have more data
-    const data = this._transform ? model.unserialize(payload) : payload
+    const data = this._transform ? PublicTrade.unserialize(payload) : payload
     const internalMessage = [chanData.chanId, eventName, data]
     internalMessage.filterOverride = [chanData.pair]
 
@@ -817,6 +816,10 @@ class WSv2 extends EventEmitter {
       if (payload) {
         this._onWSNotification(payload)
       }
+    } else if (msg[1] === 'te') {
+      msg[1] = 'auth-te'
+    } else if (msg[1] === 'tu') {
+      msg[1] = 'auth-tu'
     }
 
     this._propagateMessageToListeners(msg, chanData)
@@ -1717,6 +1720,39 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {Object} opts
+   * @param {string} opts.pair
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-trades
+   */
+  onTradeEntry ({ pair, cbGID }, cb) {
+    this._registerListener('trade-entry', { 0: pair }, PublicTrade, cbGID, cb)
+  }
+
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-public-trades
+   */
+  onAccountTradeEntry ({ symbol, cbGID }, cb) {
+    this._registerListener('auth-te', { 1: symbol }, Trade, cbGID, cb)
+  }
+
+  /**
+   * @param {Object} opts
+   * @param {string} opts.symbol
+   * @param {string} opts.cbGID - callback group id
+   * @param {Method} cb
+   * @see https://docs.bitfinex.com/v2/reference#ws-auth-trades
+   */
+  onAccountTradeUpdate ({ symbol, cbGID }, cb) {
+    this._registerListener('auth-tu', { 1: symbol }, Trade, cbGID, cb)
+  }
+
+  /**
+   * @param {Object} opts
    * @param {string} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
@@ -1845,28 +1881,6 @@ class WSv2 extends EventEmitter {
    */
   onPositionClose ({ symbol, cbGID }, cb) {
     this._registerListener('pc', { 0: symbol }, Position, cbGID, cb)
-  }
-
-  /**
-   * @param {Object} opts
-   * @param {string} opts.pair
-   * @param {string} opts.cbGID - callback group id
-   * @param {Method} cb
-   * @see https://docs.bitfinex.com/v2/reference#ws-auth-trades
-   */
-  onTradeEntry ({ pair, cbGID }, cb) {
-    this._registerListener('te', { 0: pair }, Trade, cbGID, cb)
-  }
-
-  /**
-   * @param {Object} opts
-   * @param {string} opts.pair
-   * @param {string} opts.cbGID - callback group id
-   * @param {Method} cb
-   * @see https://docs.bitfinex.com/v2/reference#ws-auth-trades
-   */
-  onTradeUpdate ({ pair, cbGID }, cb) {
-    this._registerListener('tu', { 0: pair }, Trade, cbGID, cb)
   }
 
   /**

--- a/test/lib/transports/ws2-integration.js
+++ b/test/lib/transports/ws2-integration.js
@@ -212,13 +212,13 @@ describe('WSv2 listeners', () => {
     ws._channelMap = { 0: { channel: 'auth' } }
 
     let updatesSeen = 0
-    ws.onTradeUpdate({ pair: 'tBTCUSD', cbGID: 10 }, () => updatesSeen++)
+    ws.onAccountTradeUpdate({ pair: 'BTCUSD', cbGID: 10 }, () => updatesSeen++)
     ws.onOrderUpdate({ symbol: 'tBTCUSD', cbGID: 10 }, () => updatesSeen++)
 
-    ws._handleChannelMessage([0, 'tu', ['tBTCUSD']])
+    ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
     ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
     ws.removeListeners(10)
-    ws._handleChannelMessage([0, 'tu', ['tBTCUSD']])
+    ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
     ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
 
     assert.equal(updatesSeen, 2)

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -564,24 +564,24 @@ describe('WSv2 channel msg handling', () => {
     let calls = 0
     let btcListenerCalled = false
 
-    ws.onTradeEntry({ pair: 'tBTCUSD' }, () => {
+    ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
       assert(!btcListenerCalled)
       btcListenerCalled = true
 
       if (++calls === 7) done()
     })
 
-    ws.onTradeEntry({}, () => {
+    ws.onAccountTradeEntry({}, () => {
       if (++calls === 7) done()
     })
 
-    ws.onTradeEntry({}, () => {
+    ws.onAccountTradeEntry({}, () => {
       if (++calls === 7) done()
     })
 
-    ws._handleChannelMessage([0, 'te', ['tETHUSD']])
-    ws._handleChannelMessage([0, 'te', ['tETHUSD']])
-    ws._handleChannelMessage([0, 'te', ['tBTCUSD']])
+    ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
+    ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
+    ws._handleChannelMessage([0, 'te', [123, 'tBTCUSD']])
   }
 
   it('_handleChannelMessage: filters messages if listeners require it (transform)', (done) => {
@@ -604,14 +604,14 @@ describe('WSv2 channel msg handling', () => {
       0, 'tBTCUSD', Date.now(), 0, 0.1, 1, 'type', 1, 1, 0.001, 'USD'
     ]
 
-    wsNoTransform.onTradeUpdate({}, (trade) => {
+    wsNoTransform.onAccountTradeUpdate({}, (trade) => {
       assert.equal(trade.constructor.name, 'Array')
       assert.deepEqual(trade, tradeData)
 
       if (calls++ === 1) done()
     })
 
-    wsTransform.onTradeUpdate({}, (trade) => {
+    wsTransform.onAccountTradeUpdate({}, (trade) => {
       assert.equal(trade.constructor.name, 'Trade')
       assert.equal(trade.id, tradeData[0])
       assert.equal(trade.pair, tradeData[1])
@@ -699,11 +699,11 @@ describe('WSv2 channel msg handling', () => {
     const ws = new WSv2()
     ws._channelMap = { 0: { channel: 'auth' } }
 
-    ws.onTradeEntry({ pair: 'tBTCUSD' }, () => {
+    ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
       done()
     })
 
-    ws._propagateMessageToListeners([0, 'te', ['tBTCUSD']])
+    ws._propagateMessageToListeners([0, 'auth-te', [123, 'tBTCUSD']])
   })
 
   it('_notifyCatchAllListeners: passes data to all listeners on the empty \'\' event', () => {


### PR DESCRIPTION
This PR refactors the internal trades listeners to split up public & account trades. Public `tu` events are mapped to the `onTrades()` listener along with the initial trades snapshot, being isomorphic with the other listeners (snapshot + updates). Account trades are split between `onAccountTradeEntry` and `onAccountTradeUpdate`, since there is no snapshot.

In reference to https://github.com/bitfinexcom/bitfinex-api-node/pull/388

```
const ws = bfx.ws(2)

ws.on('open', () => {
  debug('open')
  ws.subscribeTrades('tEOSUSD')
  ws.auth()
})

ws.onTradeEntry({ pair: 'EOSUSD' }, (trade) => {
  debug('te: %j', trade)
})

ws.onTrades({ pair: 'EOSUSD' }, (trades) => {
  debug('trades: %j', trades)
})

ws.onAccountTradeEntry({ symbol: 'tEOSUSD' }, (trade) => {
  debug('account te: %j', trade)
})

ws.onAccountTradeUpdate({ symbol: 'tEOSUSD' }, (trade) => {
  debug('account tu: %j', trade)
})
```