### PR TITLE
[ws2] add 'pong' event handler

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -989,6 +989,8 @@ class WSv2 extends EventEmitter {
       return this._handleConfigEvent(msg)
     } else if (msg.event === 'error') {
       return this._handleErrorEvent(msg)
+    } else if (msg.event === 'pong') {
+      return this._handlePongEvent(msg)
     }
 
     debug('recv unknown event message: %j', msg)
@@ -1018,6 +1020,16 @@ class WSv2 extends EventEmitter {
       this._enabledFlags = flags
       this._eventCallbacks.trigger(k, null, msg)
     }
+  }
+
+  /**
+   * @param {Object} msg
+   * @private
+   */
+  _handlePongEvent (msg) {
+    debug('pong: %s', JSON.stringify(msg))
+
+    this.emit('pong', msg)
   }
 
   /**


### PR DESCRIPTION
'pong' events are ignored in current ws2 implementation. 

Since the API update limiting a connection to 50 channels, one may experience no activity whatsoever for more than 10-15 seconds on a connection with illiquid coins.
Emitting a pong event back to the client allows one to make sure the connection is still up. 