### PR TITLE
Fix: Unhandled Promises

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -384,11 +384,6 @@ class WSv2 extends EventEmitter {
         debug('error triggering packet watchdog: %s', err.message)
       })
     }, this._packetWDDelay)
-
-    this._packetWDTimeout = setTimeout(
-      this._triggerPacketWD,
-      this._packetWDDelay
-    )
   }
 
   resubscribePreviousChannels () {

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -276,23 +276,19 @@ class WSv2 extends EventEmitter {
    *
    * @return {Promise} p - resolves on completion
    */
-  reconnect () {
-    if (!this._ws) return this.open()
+  async reconnect () {
+    if (!this._ws) {
+      return this.open()
+    }
 
     this._isReconnecting = true
 
-    return new Promise((resolve, reject) => {
-      this.close().then(() => {
-        this.open()
+    await this.close()
+    await this.open()
 
-        if (!this._wasEverAuthenticated) {
-          return resolve()
-        }
-
-        this._ws.once('open', this.auth.bind(this))
-        this._ws.once('auth', () => resolve())
-      })
-    })
+    if (this._wasEverAuthenticated) {
+      await this.auth()
+    }
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1104,7 +1104,9 @@ class WSv2 extends EventEmitter {
         const err = new Error(`server not running API v2: v${version}`)
 
         this.emit('error', err)
-        this.close()
+        this.close().catch((err) => {
+          debug('error closing connection: %s', err.stack)
+        })
         return
       }
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -353,7 +353,9 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _triggerPacketWD () {
-    if (!this._packetWDDelay || !this._isOpen) return
+    if (!this._packetWDDelay || !this._isOpen) {
+      return Promise.resolve()
+    }
 
     debug(
       'packet delay watchdog triggered [last packet %dms ago]',
@@ -361,7 +363,7 @@ class WSv2 extends EventEmitter {
     )
 
     this._packetWDTimeout = null
-    this.reconnect()
+    return this.reconnect()
   }
 
   /**
@@ -376,6 +378,12 @@ class WSv2 extends EventEmitter {
     }
 
     if (!this._isOpen) return
+
+    this._packetWDTimeout = setTimeout(() => {
+      this._triggerPacketWD().catch((err) => {
+        debug('error triggering packet watchdog: %s', err.message)
+      })
+    }, this._packetWDDelay)
 
     this._packetWDTimeout = setTimeout(
       this._triggerPacketWD,

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -114,7 +114,6 @@ module.exports = class WS2Manager extends EventEmitter {
       ws
     }
 
-    ws.once('open', () => debug('socket connection opened'))
     ws.on('open', () => this.emit('open', ws))
     ws.on('message', (msg = {}) => this.emit('message', msg, ws))
     ws.on('error', (error) => this.emit('error', error, ws))
@@ -160,12 +159,20 @@ module.exports = class WS2Manager extends EventEmitter {
       ws.once('open', () => {
         debug('authenticating socket...')
 
-        ws.auth(calc, dms)
-        ws.once('auth', () => debug('socket authenticated'))
+        ws.auth(calc, dms).then(() => {
+          debug('socket authenticated')
+        }).catch((err) => {
+          debug('error authenticating socket: %s', err.message)
+        })
       })
     }
 
-    ws.open()
+    ws.open().then(() => {
+      debug('socket connection opened')
+    }).catch((err) => {
+      debug('error opening socket: %s', err.stack)
+    })
+
     this._sockets.push(wsState)
     return wsState
   }


### PR DESCRIPTION
Closes #414 

Tweaks things to handle promises returned by `open()`, `close()` and `auth()` in various places, in order to avoid errors bubbling up.