### PR TITLE
v2.0.10 Fix: Ignore Notification Auth Seq Numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.10
+- WSv2: ignore notification auth seq numbers (no longer provided by API)
+
 2.0.9
 
 - WS2Manager: add managedUnsubscribe()

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -550,6 +550,8 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _onWSMessage (msgJSON, flags) {
+    debug('recv msg: %s', msgJSON)
+
     this._packetWDLastTS = Date.now()
     this._resetPacketWD()
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -326,7 +326,8 @@ class WSv2 extends EventEmitter {
     // 0 packets, these are included as the 2nd to last value
     const seq = (
       (msg[0] === 0) &&
-      (msg[1] !== 'hb')
+      (msg[1] !== 'hb') &&
+      !(msg[1] === 'n' && msg[2][1] === 'oc-req')
     )
       ? msg[msg.length - 2]
       : msg[msg.length - 1]

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -326,8 +326,7 @@ class WSv2 extends EventEmitter {
     // 0 packets, these are included as the 2nd to last value
     const seq = (
       (msg[0] === 0) &&
-      (msg[1] !== 'hb') &&
-      !(msg[1] === 'n' && msg[2][6] === 'ERROR') // error notifications lack seq
+      (msg[1] !== 'hb')
     )
       ? msg[msg.length - 2]
       : msg[msg.length - 1]
@@ -347,7 +346,7 @@ class WSv2 extends EventEmitter {
 
     if (!isFinite(authSeq)) return null
     if (authSeq === 0) return null // still syncing
-    if (msg[1] === 'n' && msg[2][6] === 'ERROR') return null // err notifications lack seq
+    if (msg[1] === 'n') return null // notifications don't advance seq
     if (authSeq === this._lastAuthSeq) return null // seq didn't advance
 
     // check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -1543,7 +1543,7 @@ describe('WSv2 seq audit: _validateMessageSeq', () => {
     assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 4]), null)
   })
 
-  it('skips auth seq for error notifications', () => {
+  it('ignores auth seq for notifications', () => {
     const ws = new WSv2()
 
     ws._seqAudit = true

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -1555,7 +1555,7 @@ describe('WSv2 seq audit: _validateMessageSeq', () => {
 
     assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 1, 1]), null)
     assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 2, 2]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nError, 3]), null)
+    assert.strictEqual(ws._validateMessageSeq([0, 'n', nError, 3, 2]), null)
     assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 4, 3]), null)
     assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 5, 4]), null)
   })


### PR DESCRIPTION
Notification sequence numbers no longer advance (deploy to production pending in the next 3 weeks), this PR removes them from consideration in the sequence audit logic.

Closes #423