### PR TITLE
Improved reconnect

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -282,12 +282,12 @@ class WSv2 extends EventEmitter {
     if (this._ws !== null && this._isOpen) {  // did we get a watchdog timeout and need to close the connection?
       await this.close()
     } else {
-      await this.reconnectAfterClose()  // we are alreacy closed, so reopen and re-auth
+      await this.reconnectAfterClose()  // we are already closed, so reopen and re-auth
     }
   }
 
   async reconnectAfterClose () {
-    if(!this._isReconnecting || this._ws !== null || this._isOpen) {
+    if (!this._isReconnecting || this._ws !== null || this._isOpen) {
       return this.reconnect()
     }
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -465,7 +465,9 @@ class WSv2 extends EventEmitter {
 
     if (this._autoReconnect && !this._isClosing) {
       this._prevChannelMap = this._channelMap
-      setTimeout(this.reconnectAfterClose.bind(this), this._reconnectDelay)
+      setTimeout(this.reconnectAfterClose.bind(this).catch((err) => {
+        debug('error reconnectAfterClose: %s', err.stack)
+      }), this._reconnectDelay)
     }
 
     this._channelMap = {}

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -465,7 +465,7 @@ class WSv2 extends EventEmitter {
 
     if (this._autoReconnect && !this._isClosing) {
       this._prevChannelMap = this._channelMap
-      setTimeout(function() {
+      setTimeout(function () {
         this.reconnectAfterClose().catch((err) => {
           debug('error reconnectAfterClose: %s', err.stack)
         })

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -225,7 +225,7 @@ class WSv2 extends EventEmitter {
       })
 
       if (!this._isClosing) {
-        this._isClosing = true
+        this._isClosing = !this._isReconnecting   // _isClosing is used to mark a user-close operation. If we are in re-connection mode, do not mark it as user-action
         this._ws.close(code, reason)
       }
     })
@@ -277,13 +277,20 @@ class WSv2 extends EventEmitter {
    * @return {Promise} p - resolves on completion
    */
   async reconnect () {
-    if (!this._ws) {
-      return this.open()
-    }
-
     this._isReconnecting = true
 
-    await this.close()
+    if (this._ws !== null && this._isOpen) {  // did we get a watchdog timeout and need to close the connection?
+      await this.close()
+    } else {
+      await this.reconnectAfterClose()  // we are alreacy closed, so reopen and re-auth
+    }
+  }
+
+  async reconnectAfterClose () {
+    if(!this._isReconnecting || this._ws !== null || this._isOpen) {
+      return this.reconnect()
+    }
+
     await this.open()
 
     if (this._wasEverAuthenticated) {
@@ -458,7 +465,7 @@ class WSv2 extends EventEmitter {
 
     if (this._autoReconnect && !this._isClosing) {
       this._prevChannelMap = this._channelMap
-      setTimeout(this.reconnect.bind(this), this._reconnectDelay)
+      setTimeout(this.reconnectAfterClose.bind(this), this._reconnectDelay)
     }
 
     this._channelMap = {}

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -463,15 +463,15 @@ class WSv2 extends EventEmitter {
 
     debug('connection closed')
 
-    if (this._isReconnecting) {
+    if (this._isReconnecting || !this._isClosing) {
       if (this._autoReconnect) {
         this._prevChannelMap = this._channelMap
       }
-      setTimeout(function () {
+      setTimeout(() => {
         this.reconnectAfterClose().catch((err) => {
           debug('error reconnectAfterClose: %s', err.stack)
         })
-      }.bind(this), this._reconnectDelay)
+      }, this._reconnectDelay)
     }
 
     this._channelMap = {}

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -463,10 +463,11 @@ class WSv2 extends EventEmitter {
 
     debug('connection closed')
 
-    if (this._isReconnecting || !this._isClosing) {
-      if (this._autoReconnect) {
-        this._prevChannelMap = this._channelMap
-      }
+    // _isReconnecting = true - if a reconnection has been requested. In that case always call reconnectAfterClose
+    // _isClosing = true - if the user explicitly requested a close
+    // _autoReconnect = true - if the user likes to reconnect automatically
+    if (this._isReconnecting || (this._autoReconnect && !this._isClosing)) {
+      this._prevChannelMap = this._channelMap
       setTimeout(() => {
         this.reconnectAfterClose().catch((err) => {
           debug('error reconnectAfterClose: %s', err.stack)

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -463,8 +463,10 @@ class WSv2 extends EventEmitter {
 
     debug('connection closed')
 
-    if (this._autoReconnect && !this._isClosing) {
-      this._prevChannelMap = this._channelMap
+    if (!this._isClosing) {
+      if (this._autoReconnect) { // remember the channels to auto-re-subscribe
+        this._prevChannelMap = this._channelMap
+      }
       setTimeout(function () {
         this.reconnectAfterClose().catch((err) => {
           debug('error reconnectAfterClose: %s', err.stack)

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -465,9 +465,11 @@ class WSv2 extends EventEmitter {
 
     if (this._autoReconnect && !this._isClosing) {
       this._prevChannelMap = this._channelMap
-      setTimeout(this.reconnectAfterClose.bind(this).catch((err) => {
-        debug('error reconnectAfterClose: %s', err.stack)
-      }), this._reconnectDelay)
+      setTimeout(function() {
+        this.reconnectAfterClose().catch((err) => {
+          debug('error reconnectAfterClose: %s', err.stack)
+        })
+      }.bind(this), this._reconnectDelay)
     }
 
     this._channelMap = {}

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -225,7 +225,7 @@ class WSv2 extends EventEmitter {
       })
 
       if (!this._isClosing) {
-        this._isClosing = !this._isReconnecting   // _isClosing is used to mark a user-close operation. If we are in re-connection mode, do not mark it as user-action
+        this._isClosing = true
         this._ws.close(code, reason)
       }
     })
@@ -463,8 +463,8 @@ class WSv2 extends EventEmitter {
 
     debug('connection closed')
 
-    if (!this._isClosing) {
-      if (this._autoReconnect) { // remember the channels to auto-re-subscribe
+    if (this._isReconnecting) {
+      if (this._autoReconnect) {
         this._prevChannelMap = this._channelMap
       }
       setTimeout(function () {

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -328,12 +328,13 @@ describe('WSv2 auto reconnect', () => {
   it('reconnects on close if autoReconnect is enabled', (done) => {
     const wss = new MockWSv2Server()
     const ws = createTestWSv2Instance({
-      autoReconnect: true
+      autoReconnect: true,
+      reconnectDelay: 1000
     })
 
     ws.on('open', ws.auth.bind(ws))
     ws.once('auth', () => {
-      ws.reconnect = () => done()
+      ws.reconnectAfterClose = () => done()
       wss.close() // trigger reconnect
     })
 

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -328,8 +328,7 @@ describe('WSv2 auto reconnect', () => {
   it('reconnects on close if autoReconnect is enabled', (done) => {
     const wss = new MockWSv2Server()
     const ws = createTestWSv2Instance({
-      autoReconnect: true,
-      reconnectDelay: 1000
+      autoReconnect: true
     })
 
     ws.on('open', ws.auth.bind(ws))
@@ -352,7 +351,7 @@ describe('WSv2 auto reconnect', () => {
     ws.once('auth', () => {
       let now = Date.now()
 
-      ws.reconnect = () => {
+      ws.reconnectAfterClose = () => {
         assert((Date.now() - now) >= 70)
         done()
       }


### PR DESCRIPTION
I found a few problems with the reconnect behavior.

The original code:
``` 
async reconnect () {
    if (!this._ws) {
      return this.open()   <-- this leads to reconnected, but unauthorized websockets, I removed that part
    }

    this._isReconnecting = true

    await this.close()   <-- this.close is calling reconnect() a second time in _onWSClose() which leads to promise rejections in different places.

    await this.open() <-- the promise rejection in open() was triggered in some edge cases because of multiple calls of reconnect()

    if (this._wasEverAuthenticated) {
      await this.auth()
    }
  }
```

I splitted the operation into two parts:

```
  async reconnect () {
    this._isReconnecting = true

    if (this._ws !== null && this._isOpen) {  // did we get a watchdog timeout and need to close the connection?
      await this.close()
    } else {
      await this.reconnectAfterClose()  // we are alreacy closed, so reopen and re-auth
    }
  }

  async reconnectAfterClose () {
    if(!this._isReconnecting || this._ws !== null || this._isOpen) {
      return this.reconnect()
    }

    await this.open()

    if (this._wasEverAuthenticated) {
      await this.auth()
    }
  }
```
The `reconnectAfterClose` is now called inside of the _onWSClose() handler (instead of `reconnect`)- so it will be tiggered in case of network loss or after a reconnect-close.

In addition there was a non-catched promise in the reconnect path in `_onWSClose` leading to application level errors.

Please check if you find it useful.