### PR TITLE
added ping method (to receive a pong, and don't trigger re-connect if…

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1433,6 +1433,20 @@ class WSv2 extends EventEmitter {
   }
 
   /**
+   * send a ping (to receive a pong)
+   * https://docs.bitfinex.com/v2/docs/ws-general#section-ping-pong
+   * @param {number} cid
+   */
+  ping (cid) {
+    const ping = {
+      "event":"ping",
+      "cid": cid
+    }
+    debug('send ping: %j', ping)
+    this. _ws.send(JSON.stringify(ping))
+  }
+
+  /**
    * Sends a new order to the server and resolves the returned promise once the
    * order submit is confirmed. Emits an error if not authenticated. The order
    * can be either an array, key/value map, or Order object instance.


### PR DESCRIPTION
… nothing happens)

Added a simple ping operation to allow an easy ping/pong.

```
ws.on('pong', message => {
// message -> {
//    "event":"pong",
//    "ts": 1511545528111,
//    "cid": 123
// }
})
ws.ping(123)
```