### PR TITLE
new example to fetch funding info

### DIFF
--- a/examples/rest2/funding_info.js
+++ b/examples/rest2/funding_info.js
@@ -1,0 +1,15 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:funding_info')
+const bfx = require('../bfx')
+const rest = bfx.rest(2)
+
+debug('fetching funding info...')
+
+rest.fundingInfo('fETH').then(fiu => {
+  fiu.forEach(fl => {
+    debug('fl: %j', fl)
+  })
+}).catch(debug)

--- a/examples/rest2/funding_info.js
+++ b/examples/rest2/funding_info.js
@@ -8,7 +8,7 @@ const rest = bfx.rest(2)
 
 debug('fetching funding info...')
 
-rest.fundingInfo('fETH').then(fiu => {
+rest.fundingInfo('fUSD').then(fiu => {
   fiu.forEach(fl => {
     debug('fl: %j', fl)
   })


### PR DESCRIPTION
add the fundingInfo example. 

https://docs.bitfinex.com/v2/reference#rest-auth-info-funding
I found the DURATION_LEND is updated correctly but the YIELD_LEND is not updated