### PR TITLE
Fix: Funding trade event routing 3.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.1
+- WSv2: fix fte and ftu event routing
+
 4.0.0
 - include bfx-api-node-rest takeNotification hotfix
 

--- a/examples/ws2/trades.js
+++ b/examples/ws2/trades.js
@@ -10,7 +10,16 @@ const ws = bfx.ws(2)
 ws.on('open', () => {
   debug('open')
   ws.subscribeTrades('tEOSUSD')
+  ws.subscribeTrades('fUSD')
   ws.auth()
+})
+
+ws.onFundingTradeEntry({ symbol: 'fUSD' }, (trade) => {
+  debug('fte: %j', trade)
+})
+
+ws.onFundingTradeUpdate({ symbol: 'fUSD' }, (trade) => {
+  debug('ftu: %j', trade)
 })
 
 ws.onTradeEntry({ symbol: 'tEOSUSD' }, (trade) => {
@@ -18,7 +27,11 @@ ws.onTradeEntry({ symbol: 'tEOSUSD' }, (trade) => {
 })
 
 ws.onTrades({ symbol: 'tEOSUSD' }, (trades) => {
-  debug('trades: %j', trades)
+  debug('tEOSUSD trades: %j', trades)
+})
+
+ws.onTrades({ symbol: 'fUSD' }, (trades) => {
+  debug('fUSD trades: %j', trades)
 })
 
 ws.onAccountTradeEntry({ symbol: 'tEOSUSD' }, (trade) => {

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1872,7 +1872,7 @@ class WSv2 extends EventEmitter {
     const id = pair || symbol || ''
     const model = id[0] === 'f' ? FundingTrade : PublicTrade
 
-    this._registerListener('trades', { 0: id }, PublicTrade, cbGID, cb)
+    this._registerListener('trades', { 0: id }, model, cbGID, cb)
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -768,19 +768,29 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleTradeMessage (msg, chanData) {
-    const eventName = msg[1] === 'te' ? 'trade-entry' : 'trades'
+    const eventName = msg[1][0] === 'f'
+      ? msg[1] // Funding trades are passed to fte/ftu handlers
+      : msg[1] === 'te'
+        ? 'trade-entry'
+        : 'trades'
+
     let payload = getMessagePayload(msg)
 
     if (!Array.isArray(payload[0])) {
       payload = [payload]
     }
 
-    const data = this._transform ? PublicTrade.unserialize(payload) : payload
+    const data = !this._transform
+      ? payload
+      : eventName[0] === 'f'
+        ? FundingTrade.unserialize(payload)
+        : PublicTrade.unserialize(payload)
+
     const internalMessage = [chanData.chanId, eventName, data]
-    internalMessage.filterOverride = [chanData.symbol]
+    internalMessage.filterOverride = [chanData.pair || chanData.symbol]
 
     this._propagateMessageToListeners(internalMessage, chanData, false)
-    this.emit('trades', chanData.pair, data)
+    this.emit('trades', chanData.pair || chanData.symbol, data)
   }
 
   /**
@@ -1852,13 +1862,17 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {Object} opts
-   * @param {string} opts.pair
+   * @param {string?} opts.pair
+   * @param {string?} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-public-trades
    */
-  onTrades ({ symbol, cbGID }, cb) {
-    this._registerListener('trades', { 0: symbol }, PublicTrade, cbGID, cb)
+  onTrades ({ symbol, pair, cbGID }, cb) {
+    const id = pair || symbol || ''
+    const model = id[0] === 'f' ? FundingTrade : PublicTrade
+
+    this._registerListener('trades', { 0: id }, PublicTrade, cbGID, cb)
   }
 
   /**
@@ -2214,24 +2228,26 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {Object} opts
-   * @param {string} opts.symbol
+   * @param {string?} opts.pair
+   * @param {string?} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-funding-trades
    */
-  onFundingTradeEntry ({ symbol, cbGID }, cb) {
-    this._registerListener('fte', { 1: symbol }, FundingTrade, cbGID, cb)
+  onFundingTradeEntry ({ pair, symbol, cbGID }, cb) {
+    this._registerListener('fte', { 0: pair || symbol }, FundingTrade, cbGID, cb)
   }
 
   /**
    * @param {Object} opts
-   * @param {string} opts.symbol
+   * @param {string?} opts.pair
+   * @param {string?} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-funding-trades
    */
-  onFundingTradeUpdate ({ symbol, cbGID }, cb) {
-    this._registerListener('ftu', { 1: symbol }, FundingTrade, cbGID, cb)
+  onFundingTradeUpdate ({ pair, symbol, cbGID }, cb) {
+    this._registerListener('ftu', { 0: pair || symbol }, FundingTrade, cbGID, cb)
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -2228,26 +2228,24 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {Object} opts
-   * @param {string?} opts.pair
    * @param {string?} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-funding-trades
    */
-  onFundingTradeEntry ({ pair, symbol, cbGID }, cb) {
-    this._registerListener('fte', { 0: pair || symbol }, FundingTrade, cbGID, cb)
+  onFundingTradeEntry ({ symbol, cbGID }, cb) {
+    this._registerListener('fte', { 0: symbol }, FundingTrade, cbGID, cb)
   }
 
   /**
    * @param {Object} opts
-   * @param {string?} opts.pair
    * @param {string?} opts.symbol
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-auth-funding-trades
    */
-  onFundingTradeUpdate ({ pair, symbol, cbGID }, cb) {
-    this._registerListener('ftu', { 0: pair || symbol }, FundingTrade, cbGID, cb)
+  onFundingTradeUpdate ({ symbol, cbGID }, cb) {
+    this._registerListener('ftu', { 0: symbol }, FundingTrade, cbGID, cb)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -1601,6 +1601,58 @@ describe('_handleTradeMessage', () => {
       pair: 'tBTCUSD'
     })
   })
+
+  it('correctly forwards funding trades', (done) => {
+    const ws = new WSv2()
+    const payload = [
+      [286614318, 1535531325604, 0.05, 7073.51178714],
+      [286614249, 1535531321436, 0.0215938, 7073.6],
+      [286614248, 1535531321430, 0.0284062, 7073.51178714]
+    ]
+    const msg = [1710, payload, 1]
+
+    ws.onTrades({ pair: 'fUSD' }, (data) => {
+      assert.deepStrictEqual(data, payload)
+      done()
+    })
+
+    ws._handleTradeMessage(msg, {
+      channel: 'trades',
+      pair: 'fUSD'
+    })
+  })
+
+  it('correctly routes fte packets', (done) => {
+    const ws = new WSv2()
+    const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
+    const msg = [0, 'fte', payload]
+
+    ws.onFundingTradeEntry({ pair: 'tBTCUSD' }, (data) => {
+      assert.deepStrictEqual(data[0], payload)
+      done()
+    })
+
+    ws._handleTradeMessage(msg, {
+      channel: 'fte',
+      pair: 'tBTCUSD'
+    })
+  })
+
+  it('correctly routes ftu packets', (done) => {
+    const ws = new WSv2()
+    const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
+    const msg = [0, 'ftu', payload]
+
+    ws.onFundingTradeUpdate({ pair: 'tBTCUSD' }, (data) => {
+      assert.deepStrictEqual(data[0], payload)
+      done()
+    })
+
+    ws._handleTradeMessage(msg, {
+      channel: 'ftu',
+      pair: 'tBTCUSD'
+    })
+  })
 })
 
 describe('resubscribePreviousChannels', () => {


### PR DESCRIPTION
Properly route `fte`/`ftu` messages to their respective handlers, closes #456

* [x] tests
* [x] version bumped
* [x] changelog bumped