### PR TITLE
set lastMidPrice value

### DIFF
--- a/examples/ws2/order_books.js
+++ b/examples/ws2/order_books.js
@@ -32,6 +32,8 @@ ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
       midPrice, ob.bids[0][0], ob.asks[0][0]
     )
   }
+  
+  lastMidPrice = midPrice
 })
 
 ws.open()

--- a/examples/ws2/order_books.js
+++ b/examples/ws2/order_books.js
@@ -32,7 +32,7 @@ ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
       midPrice, ob.bids[0][0], ob.asks[0][0]
     )
   }
-  
+
   lastMidPrice = midPrice
 })
 


### PR DESCRIPTION
I haven't tested the script, but it looks like lastMidPrice will always be set to -1. Added L36 to set lastMidPrice to the current midPrice value so the if statement won't return TRUE on every order book update.