### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "standard": "^10.0.2"
   },
   "dependencies": {
-    "bfx-api-node-models": "^1.0.8",
-    "bfx-api-node-rest": "^1.1.1",
-    "bfx-api-node-util": "^1.0.1",
+    "bfx-api-node-models": "^1.0.11",
+    "bfx-api-node-rest": "^1.1.3",
+    "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
     "bignumber.js": "^6.0.0",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
### Description:
...
Update min dependencies to: 
"bfx-api-node-models": "^1.0.11",
"bfx-api-node-rest": "^1.1.3",
"bfx-api-node-util": "^1.0.2",

### Breaking changes:
- way how nonce is calculated had changed, on https://github.com/bitfinexcom/bfx-api-node-util/pull/5 adding better compatibility between rest v1 and v2

### New features:
- Added enpoints to bfx-api-node-rest
- Added models to bfx-api-node-models

### Fixes:
- Compatibility between rest endpoints v1 and v2 

### PR status:
- Version bumped 2.0.8
