### PR TITLE
Integrate v2 endpoints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+3.0.0
+- Updates function rest2.withdraw to v2 functionality
+- Updates function rest2.transfer to v2 functionality
+- adds function rest2.getDepositAddress
+- adds function rest2.submitAutoFunding
+- adds function rest2.closeFunding
+- adds function rest2.cancelFundingOffer
+- adds function rest2.submitFundingOffer
+- adds function rest2.claimPosition
+- adds function rest2.cancelOrder
+- adds function rest2.updateOrder
+- adds function rest2.submitOrder
+
 2.0.10
 - WSv2: ignore notification auth seq numbers (no longer provided by API)
 

--- a/examples/rest2/positions.js
+++ b/examples/rest2/positions.js
@@ -7,6 +7,7 @@ const debug = require('debug')('bfx:examples:rest2_positions')
 const bfx = require('../bfx')
 const rest = bfx.rest(2, { transform: true })
 
+
 const PL_ENABLED = process.argv[2] === 'pl'
 const tableColWidths = [20, 10, 20, 20, 20]
 const tableHeaders = [
@@ -75,7 +76,11 @@ const example = async () => {
     t.push(data)
   }
 
-  console.log(t.toString())
+  // claim all position
+  // positions.map((p) => {
+  //   p.claim()
+  // })
 }
+
 
 example().catch(debug)

--- a/examples/rest2/positions.js
+++ b/examples/rest2/positions.js
@@ -7,7 +7,6 @@ const debug = require('debug')('bfx:examples:rest2_positions')
 const bfx = require('../bfx')
 const rest = bfx.rest(2, { transform: true })
 
-
 const PL_ENABLED = process.argv[2] === 'pl'
 const tableColWidths = [20, 10, 20, 20, 20]
 const tableHeaders = [
@@ -81,6 +80,5 @@ const example = async () => {
   //   p.claim()
   // })
 }
-
 
 example().catch(debug)

--- a/examples/rest2/submit_funding_offer.js
+++ b/examples/rest2/submit_funding_offer.js
@@ -9,8 +9,8 @@ const rest = bfx.rest(2, { transform: true })
 
 debug('Submitting new order...')
 
- // Build new order
- const fo = new FundingOffer({
+// Build new order
+const fo = new FundingOffer({
   type: 'LIMIT',
   symbol: 'fUSD',
   rate: 0.0120000,
@@ -19,9 +19,9 @@ debug('Submitting new order...')
 }, rest)
 
 fo.submit().then((fo) => {
-  debug("Submitted funding offer", fo.id)
+  debug('Submitted funding offer', fo.id)
 })
-.catch((err) => console.log(err))
+  .catch((err) => console.log(err))
 
 // cancel offer
 

--- a/examples/rest2/submit_funding_offer.js
+++ b/examples/rest2/submit_funding_offer.js
@@ -1,0 +1,34 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:submit_order')
+const bfx = require('../bfx')
+const { FundingOffer } = require('bfx-api-node-models')
+const rest = bfx.rest(2, { transform: true })
+
+debug('Submitting new order...')
+
+ // Build new order
+ const fo = new FundingOffer({
+  type: 'LIMIT',
+  symbol: 'fUSD',
+  rate: 0.0120000,
+  amount: 120,
+  period: 2
+}, rest)
+
+fo.submit().then((fo) => {
+  debug("Submitted funding offer", fo.id)
+})
+.catch((err) => console.log(err))
+
+// cancel offer
+
+// setTimeout(() => {
+//   fo.cancel()
+// }, 5000)
+
+setTimeout(() => {
+  fo.close()
+}, 5000)

--- a/examples/rest2/submit_order.js
+++ b/examples/rest2/submit_order.js
@@ -1,0 +1,40 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:submit_order')
+const bfx = require('../bfx')
+const { Order } = require('bfx-api-node-models')
+const rest = bfx.rest(2)
+
+debug('Submitting new order...')
+
+ // Build new order
+ const o = new Order({
+  cid: Date.now(),
+  symbol: 'tBTCUSD',
+  price: 18000,
+  amount: -0.02,
+  type: Order.type.LIMIT,
+  lev: 10
+}, rest)
+
+o.submit().then(() => {
+  debug(
+    'got submit confirmation for order %d [%d] [tif: %d]',
+    o.cid, o.id, o.mtsTIF
+  )
+})
+.catch((err) => console.log(err))
+
+// update order
+
+setTimeout(() => {
+  o.update({
+    price: 17000
+  })
+}, 5000)
+
+setTimeout(() => {
+  o.cancel()
+},10000)

--- a/examples/rest2/submit_order.js
+++ b/examples/rest2/submit_order.js
@@ -9,8 +9,8 @@ const rest = bfx.rest(2)
 
 debug('Submitting new order...')
 
- // Build new order
- const o = new Order({
+// Build new order
+const o = new Order({
   cid: Date.now(),
   symbol: 'tBTCUSD',
   price: 18000,
@@ -25,7 +25,7 @@ o.submit().then(() => {
     o.cid, o.id, o.mtsTIF
   )
 })
-.catch((err) => console.log(err))
+  .catch((err) => console.log(err))
 
 // update order
 
@@ -37,4 +37,4 @@ setTimeout(() => {
 
 setTimeout(() => {
   o.cancel()
-},10000)
+}, 10000)

--- a/examples/rest2/wallet.js
+++ b/examples/rest2/wallet.js
@@ -8,15 +8,15 @@ const rest = bfx.rest(2, { transform: true })
 
 debug('Submitting new order...')
 
- // get new deposit address
- rest.getDepositAddress ({
+// get new deposit address
+rest.getDepositAddress({
   wallet: 'exchange',
   method: 'bitcoin',
   opRenew: 0
- })
-.then((address) => {
-  debug(`New wallet address ${address}`)
 })
+  .then((address) => {
+    debug(`New wallet address ${address}`)
+  })
 
 // transfer between accounts
 rest.transfer({
@@ -26,9 +26,9 @@ rest.transfer({
   currency: 'BTC',
   currencyTo: 'BTC'
 })
-.then((res) => {
-  debug(`transfer confirmed: ${res}`)
-})
+  .then((res) => {
+    debug(`transfer confirmed: ${res}`)
+  })
 
 // withdraw
 rest.withdraw({
@@ -37,6 +37,6 @@ rest.withdraw({
   amount: 2,
   address: '1MUz4VMYui5qY1mxUiG8BQ1Luv6tqkvaiL'
 })
-.then((res) => {
-  debug(`withdraw confirmed: ${res}`)
-})
+  .then((res) => {
+    debug(`withdraw confirmed: ${res}`)
+  })

--- a/examples/rest2/wallet.js
+++ b/examples/rest2/wallet.js
@@ -1,0 +1,42 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:*'
+
+const debug = require('debug')('bfx:examples:submit_order')
+const bfx = require('../bfx')
+const rest = bfx.rest(2, { transform: true })
+
+debug('Submitting new order...')
+
+ // get new deposit address
+ rest.getDepositAddress ({
+  wallet: 'exchange',
+  method: 'bitcoin',
+  opRenew: 0
+ })
+.then((address) => {
+  debug(`New wallet address ${address}`)
+})
+
+// transfer between accounts
+rest.transfer({
+  from: 'exchange',
+  to: 'margin',
+  amount: 10,
+  currency: 'BTC',
+  currencyTo: 'BTC'
+})
+.then((res) => {
+  debug(`transfer confirmed: ${res}`)
+})
+
+// withdraw
+rest.withdraw({
+  wallet: 'exchange',
+  method: 'bitcoin',
+  amount: 2,
+  address: '1MUz4VMYui5qY1mxUiG8BQ1Luv6tqkvaiL'
+})
+.then((res) => {
+  debug(`withdraw confirmed: ${res}`)
+})

--- a/examples/ws2/candles.js
+++ b/examples/ws2/candles.js
@@ -24,7 +24,7 @@ ws.onCandle({ key: CANDLE_KEY }, (candles) => {
   if (prevTS === null || candles[0].mts > prevTS) {
     const c = candles[1] // report previous candle
 
-    debug(`%s %s open: %f, high: %f, low: %f, close: %f, volume: %f`,
+    debug('%s %s open: %f, high: %f, low: %f, close: %f, volume: %f',
       CANDLE_KEY, new Date(c.mts).toLocaleTimeString(),
       c.open, c.high, c.low, c.close, c.volume
     )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "2.0.10",
+  "version": "3.0.0",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "standard": "^10.0.2"
   },
   "dependencies": {
-    "bfx-api-node-models": "^1.0.11",
-    "bfx-api-node-rest": "^1.1.3",
+    "bfx-api-node-models": "^1.1.0",
+    "bfx-api-node-rest": "^2.0.0",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
     "bignumber.js": "^6.0.0",

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -38,7 +38,7 @@ describe('WSv2 utilities', () => {
     const listener = listenerSet.trade[0]
 
     assert.strictEqual(listener.modelClass, Map)
-    assert.deepStrictEqual(listener.filter, { '2': 'tBTCUSD' })
+    assert.deepStrictEqual(listener.filter, { 2: 'tBTCUSD' })
     assert.strictEqual(typeof listener.cb, 'function')
   })
 
@@ -349,7 +349,7 @@ describe('WSv2 auto reconnect', () => {
 
     ws.on('open', ws.auth.bind(ws))
     ws.once('auth', () => {
-      let now = Date.now()
+      const now = Date.now()
 
       ws.reconnectAfterClose = () => {
         assert((Date.now() - now) >= 70)
@@ -674,8 +674,8 @@ describe('WSv2 channel msg handling', () => {
 
     const lg = {
       '': [{ cb: func }],
-      'test': [{ cb: func }],
-      'nope': [{ cb: func }]
+      test: [{ cb: func }],
+      nope: [{ cb: func }]
     }
 
     WSv2._notifyListenerGroup(lg, [0, 'test', [0, 'tu']], false)
@@ -683,7 +683,7 @@ describe('WSv2 channel msg handling', () => {
 
   it('_notifyListenerGroup: doesn\'t fail on missing data if filtering', (done) => {
     const lg = {
-      'test': [{
+      test: [{
         filter: { 1: 'on' },
         cb: () => {
           done(new Error('filter should not have matched'))
@@ -726,14 +726,18 @@ describe('WSv2 channel msg handling', () => {
       transform: true
     })
 
-    ws._channelMapA = { 42: {
-      channel: 'orderbook',
-      symbol: 'tBTCUSD'
-    } }
-    ws._channelMapB = { 43: {
-      channel: 'orderbook',
-      symbol: 'fUSD'
-    } }
+    ws._channelMapA = {
+      42: {
+        channel: 'orderbook',
+        symbol: 'tBTCUSD'
+      }
+    }
+    ws._channelMapB = {
+      43: {
+        channel: 'orderbook',
+        symbol: 'fUSD'
+      }
+    }
 
     ws._handleOBMessage([42, [
       [100, 2, -4],
@@ -778,10 +782,12 @@ describe('WSv2 channel msg handling', () => {
       transform: true
     })
 
-    wsNoTransform._channelMap = { 42: {
-      channel: 'orderbook',
-      symbol: 'tBTCUSD'
-    } }
+    wsNoTransform._channelMap = {
+      42: {
+        channel: 'orderbook',
+        symbol: 'tBTCUSD'
+      }
+    }
 
     wsTransform._channelMap = wsNoTransform._channelMap
 
@@ -801,10 +807,12 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleOBMessage: forwards managed ob to listeners', (done) => {
     const ws = new WSv2({ manageOrderBooks: true })
-    ws._channelMap = { 42: {
-      channel: 'orderbook',
-      symbol: 'tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        channel: 'orderbook',
+        symbol: 'tBTCUSD'
+      }
+    }
 
     let seen = 0
     ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
@@ -861,10 +869,12 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleOBMessage: emits managed ob', (done) => {
     const ws = new WSv2({ manageOrderBooks: true })
-    ws._channelMap = { 42: {
-      channel: 'orderbook',
-      symbol: 'tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        channel: 'orderbook',
+        symbol: 'tBTCUSD'
+      }
+    }
 
     ws.on('orderbook', (symbol, data) => {
       assert.strictEqual(symbol, 'tBTCUSD')
@@ -877,11 +887,13 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleOBMessage: forwards transformed data if transform enabled', (done) => {
     const ws = new WSv2({ transform: true })
-    ws._channelMap = { 42: {
-      chanId: 42,
-      channel: 'orderbook',
-      symbol: 'tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        chanId: 42,
+        channel: 'orderbook',
+        symbol: 'tBTCUSD'
+      }
+    }
 
     ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
       assert(ob.asks)
@@ -940,10 +952,12 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleCandleMessage: maintains internal candles if management is enabled', () => {
     const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = { 64: {
-      channel: 'candles',
-      key: 'trade:1m:tBTCUSD'
-    } }
+    ws._channelMap = {
+      64: {
+        channel: 'candles',
+        key: 'trade:1m:tBTCUSD'
+      }
+    }
 
     ws._handleCandleMessage([64, [
       [5, 100, 70, 150, 30, 1000],
@@ -1014,11 +1028,13 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleCandleMessage: forwards managed candles to listeners', (done) => {
     const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = { 42: {
-      chanId: 42,
-      channel: 'candles',
-      key: 'trade:1m:tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        chanId: 42,
+        channel: 'candles',
+        key: 'trade:1m:tBTCUSD'
+      }
+    }
 
     let seen = 0
     ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (data) => {
@@ -1039,10 +1055,12 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleCandleMessage: emits managed candles', (done) => {
     const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = { 42: {
-      channel: 'candles',
-      key: 'trade:1m:tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        channel: 'candles',
+        key: 'trade:1m:tBTCUSD'
+      }
+    }
 
     ws.on('candle', (data, key) => {
       assert.strictEqual(key, 'trade:1m:tBTCUSD')
@@ -1058,11 +1076,13 @@ describe('WSv2 channel msg handling', () => {
 
   it('_handleCandleMessage: forwards transformed data if transform enabled', (done) => {
     const ws = new WSv2({ transform: true })
-    ws._channelMap = { 42: {
-      chanId: 42,
-      channel: 'candles',
-      key: 'trade:1m:tBTCUSD'
-    } }
+    ws._channelMap = {
+      42: {
+        chanId: 42,
+        channel: 'candles',
+        key: 'trade:1m:tBTCUSD'
+      }
+    }
 
     ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (candles) => {
       assert.strictEqual(candles.length, 1)


### PR DESCRIPTION
### Description:
Adds new V2 endpoints to the lib:

```
 `/v2/auth/w/order/submit` (same data used in sending orders through WS, `on`)
  `/v2/auth/w/order/update`  (same data used in sending orders through WS, `ou`)
  `/v2/auth/w/order/cancel` (same data used in sending orders through WS, `oc`)
  `/v2/auth/w/order/multi`  (same data used in sending orders through WS `ox_multi`, but inside an array called `ops`, ie. `{"ops": [["on", {"symbol": "tBTCUSD", "amount": "5", "type": "LIMIT", "price": "10"}]]}`)
  `/v2/auth/w/order/cancel/multi` (same data used in sending orders through WS, `oc`)
  `/v2/auth/w/position/claim` (params: `id`)
  `/v2/auth/w/funding/offer/submit` (same data used in sending orders through WS, `on`)
  `/v2/auth/w/funding/offer/cancel` (same data used in sending orders through WS, `on`)
  `/v2/auth/w/funding/close` (params: `id`, `type` (credit|loan))
  `/v2/auth/w/funding/auto` (params: `status` (1|0), `currency`, `amount`, `rate`, `period`) (`rate === 0` means `FRR`)
  `/v2/auth/w/transfer` (params: `from`, `to`, `currency`, `currency_to`, `amount`)
  `/v2/auth/w/deposit/address` (params: `wallet`, `method`, `op_renew`(=1 to regenerate the wallet address))
  `/v2/auth/w/withdraw` (params: `wallet`, `method`, `amount`, `address
```

### Breaking changes:
Originally the lib forwarded any calls to `rest2.withdraw` and `rest2.transfer` to the v1 endpoint but since the v2 endpoints for these actions require different params then anyone using the old param style will encounter an error. To solve this I have bumped the major version of the lib

- [x] legacy V1 routing (see above)

### New features:
- [x] `rest2.withdraw`
- [x] `rest2.getDepositAddress`
- [x] `rest2.transfer`
- [x] `rest2.submitAutoFunding`
- [x] `rest2.closeFunding`
- [x] `rest2.cancelFundingOffer`
- [x] `rest2.submitFundingOffer`
- [x] `rest2.claimPosition`
- [x] `rest2.cancelOrder`
- [x] `rest2.updateOrder`
- [x] `rest2.submitOrder`

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
