### PR TITLE
freq added to order book filter in ws2 manager

### DIFF
--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -349,13 +349,15 @@ module.exports = class WS2Manager extends EventEmitter {
    * @param {string} symbol
    * @param {string} prec
    * @param {string} len
+   * @param {string} freq
    */
-  subscribeOrderBook (symbol, prec = 'P0', len = '25') {
+  subscribeOrderBook (symbol, prec = 'P0', len = '25', freq = 'F0') {
     const filter = {}
 
     if (symbol) filter.symbol = symbol
     if (prec) filter.prec = prec
     if (len) filter.len = len
+    if (freq) filter.freq = freq
 
     return this.subscribe('book', symbol, filter)
   }
@@ -389,16 +391,18 @@ module.exports = class WS2Manager extends EventEmitter {
    * @param {string} opts.symbol
    * @param {string} opts.prec
    * @param {string} opts.len
+   * @param {string} opts.freq
    * @param {string} opts.cbGID - callback group id
    * @param {Method} cb
    * @see https://docs.bitfinex.com/v2/reference#ws-public-order-books
    */
-  onOrderBook ({ symbol, prec = 'P0', len = '25', cbGID }, cb) {
+  onOrderBook ({ symbol, prec = 'P0', len = '25', freq = 'F0', cbGID }, cb) {
     const filter = {}
 
     if (symbol) filter.symbol = symbol
     if (prec) filter.prec = prec
     if (len) filter.len = len
+    if (freq) filter.freq = freq
 
     const s = this.getSocketWithDataChannel('book', filter)
 


### PR DESCRIPTION
### Description:
Added freq attribute to filters inside order book subscription in ws2 manager (see [docs](https://docs.bitfinex.com/reference#ws-public-order-books) for missing param)

### Breaking changes:
- N/A

### New features:
- N/A

### Fixes:
- Added support for missing optional param inside subscribe to order books channel
