### PR TITLE
bump package to 4.0.0 and include node-rest hotfix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.0
+- include bfx-api-node-rest takeNotification hotfix
+
 3.0.2
 - WSv2: affCode support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "bfx-api-node-models": "^1.1.0",
-    "bfx-api-node-rest": "^2.0.0",
+    "bfx-api-node-rest": "^3.0.0",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
     "bignumber.js": "^6.0.0",


### PR DESCRIPTION
### Description:
A API breaking fix was added to bfx-api-node-rest and this pull request adds it.

### Breaking changes:
Please see https://github.com/bitfinexcom/bfx-api-node-rest/pull/42

### PR status:
- [x] Version bumped
- [x] Change-log updated
