### PR TITLE
Add reconnect() method to ws2 manager 4.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.2
+- WS2Manager: add reconnect method
+
 4.0.1
 - WSv2: fix fte and ftu event routing
 

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -42,6 +42,13 @@ class WS2Manager extends EventEmitter {
   }
 
   /**
+   * Reconnects all open sockets
+   */
+  reconnect () {
+    this._sockets.forEach(socket => socket.ws.reconnect())
+  }
+
+  /**
    * Closes all open sockets
    */
   close () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Adds a `reconnect()` method to the WSv2 Manager class, which calls `reconnect()` on all sockets.

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
