### PR TITLE
Generate checksum using strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+4.0.4
+- Orderbook: generate and update book using lossless string format
+  in order to prevent floating point precision checksum errors:
+  https://github.com/bitfinexcom/bitfinex-api-node/issues/511
+
 4.0.3
 - WS2Manager: add setAuthArgs method
 

--- a/docs/ws2.md
+++ b/docs/ws2.md
@@ -14,6 +14,7 @@ Communicates with v2 of the Bitfinex WebSocket API
     * [._validateMessageSeq(msg)](#WSv2+_validateMessageSeq) ⇒ <code>Error</code>
     * [._verifyManagedOBChecksum(symbol, prec, cs)](#WSv2+_verifyManagedOBChecksum) ⇒ <code>Error</code>
     * [.getOB(symbol)](#WSv2+getOB) ⇒ <code>OrderBook</code>
+    * [.getLosslessOB(symbol)](#WSv2+getLosslessOB) ⇒ <code>OrderBook</code>
     * [.getCandles(key)](#WSv2+getCandles) ⇒ <code>Array</code>
     * [.managedSubscribe(channel, identifier, payload)](#WSv2+managedSubscribe) ⇒ <code>boolean</code>
     * [.managedUnsubscribe(channel, identifier)](#WSv2+managedUnsubscribe) ⇒ <code>boolean</code>
@@ -187,6 +188,21 @@ The last-seen sequence #s are updated internally.
 ### wSv2.getOB(symbol) ⇒ <code>OrderBook</code>
 Returns an up-to-date copy of the order book for the specified symbol, or
 null if no OB is managed for that symbol.
+Set `manageOrderBooks: true` in the constructor to use.
+
+**Kind**: instance method of [<code>WSv2</code>](#WSv2)  
+**Returns**: <code>OrderBook</code> - ob - null if not found  
+
+| Param | Type |
+| --- | --- |
+| symbol | <code>string</code> | 
+
+<a name="WSv2+getLosslessOB"></a>
+
+### wSv2.getLosslessOB(symbol) ⇒ <code>OrderBook</code>
+Returns an up-to-date lossless copy of the order book for the specified symbol, or
+null if no OB is managed for that symbol. All amounts and prices are in original
+string format.
 Set `manageOrderBooks: true` in the constructor to use.
 
 **Kind**: instance method of [<code>WSv2</code>](#WSv2)  
@@ -660,6 +676,7 @@ received.
 | --- | --- | --- |
 | opts | <code>Object</code> |  |
 | opts.pair | <code>string</code> |  |
+| opts.symbol | <code>string</code> |  |
 | opts.cbGID | <code>string</code> | callback group id |
 | cb | <code>Method</code> |  |
 

--- a/examples/ws2/ob_checksum.js
+++ b/examples/ws2/ob_checksum.js
@@ -6,9 +6,9 @@ const debug = require('debug')('bfx:examples:ws2_ob_checksum')
 const bfx = require('../bfx')
 const WSv2 = require('../../lib/transports/ws2')
 
-const SYMBOL = 'tBTCUSD'
-const PRECISION = 'R0'
-const LENGTH = '100'
+const SYMBOL = 'tXRPBTC'
+const PRECISION = 'P0'
+const LENGTH = '25'
 
 const ws = bfx.ws(2, {
   manageOrderBooks: true // managed OBs are verified against incoming checksums

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -676,7 +676,6 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleOBMessage (msg, chanData, rawMsg) {
-
     const { symbol, prec } = chanData
     const raw = prec === 'R0'
     let data = getMessagePayload(msg)
@@ -722,9 +721,8 @@ class WSv2 extends EventEmitter {
     const rawLossless = LosslessJSON.parse(rawMsg, (key, value) => {
       if (value && value.isLosslessNumber) {
         return value.toString()
-      }
-      else {
-        return value;
+      } else {
+        return value
       }
     })
     const losslessUpdate = rawLossless[1]

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -14,6 +14,7 @@ const _pick = require('lodash/pick')
 const _isEqual = require('lodash/isEqual')
 const { genAuthSig, nonce } = require('bfx-api-node-util')
 const getMessagePayload = require('../util/ws2')
+const LosslessJSON = require('lossless-json')
 
 const {
   BalanceInfo,
@@ -104,6 +105,7 @@ class WSv2 extends EventEmitter {
     this._packetWDTimeout = null
     this._packetWDLastTS = 0
     this._orderBooks = {}
+    this._losslessOrderBooks = {}
     this._candles = {}
 
     /**
@@ -553,12 +555,12 @@ class WSv2 extends EventEmitter {
   }
 
   /**
-   * @param {string} msgJSON
+   * @param {string} rawMsg
    * @param {string} flags
    * @private
    */
-  _onWSMessage (msgJSON, flags) {
-    debug('recv msg: %s', msgJSON)
+  _onWSMessage (rawMsg, flags) {
+    debug('recv msg: %s', rawMsg)
 
     this._packetWDLastTS = Date.now()
     this._resetPacketWD()
@@ -566,9 +568,9 @@ class WSv2 extends EventEmitter {
     let msg
 
     try {
-      msg = JSON.parse(msgJSON)
+      msg = JSON.parse(rawMsg)
     } catch (e) {
-      this.emit('error', `invalid message JSON: ${msgJSON}`)
+      this.emit('error', `invalid message JSON: ${rawMsg}`)
       return
     }
 
@@ -585,9 +587,9 @@ class WSv2 extends EventEmitter {
     this.emit('message', msg, flags)
 
     if (Array.isArray(msg)) {
-      this._handleChannelMessage(msg)
+      this._handleChannelMessage(msg, rawMsg)
     } else if (msg.event) {
-      this._handleEventMessage(msg)
+      this._handleEventMessage(msg, rawMsg)
     } else {
       debug('recv unidentified message: %j', msg)
     }
@@ -595,9 +597,10 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {array} msg
+   * @param {string} rawMsg
    * @private
    */
-  _handleChannelMessage (msg) {
+  _handleChannelMessage (msg, rawMsg) {
     const [chanId, type] = msg
     const channelData = this._channelMap[chanId]
 
@@ -614,7 +617,7 @@ class WSv2 extends EventEmitter {
         return this._handleOBChecksumMessage(msg, channelData)
       }
 
-      return this._handleOBMessage(msg, channelData)
+      return this._handleOBMessage(msg, channelData, rawMsg)
     } else if (channelData.channel === 'trades') {
       return this._handleTradeMessage(msg, channelData)
     } else if (channelData.channel === 'ticker') {
@@ -669,15 +672,17 @@ class WSv2 extends EventEmitter {
    *
    * @param {Array|Array[]} msg
    * @param {Object} chanData - entry from _channelMap
+   * @param {string} rawMsg
    * @private
    */
-  _handleOBMessage (msg, chanData) {
+  _handleOBMessage (msg, chanData, rawMsg) {
+
     const { symbol, prec } = chanData
     const raw = prec === 'R0'
     let data = getMessagePayload(msg)
 
     if (this._manageOrderBooks) {
-      const err = this._updateManagedOB(symbol, data, raw)
+      const err = this._updateManagedOB(symbol, data, raw, rawMsg)
 
       if (err) {
         this.emit('error', err)
@@ -710,11 +715,24 @@ class WSv2 extends EventEmitter {
    * @return {Error} err - null on success
    * @private
    */
-  _updateManagedOB (symbol, data, raw) {
+  _updateManagedOB (symbol, data, raw, rawMsg) {
+    // parse raw string with lossless parse which takes
+    // the exact strict values rather than converting to floats
+    // [0.00001, [1, 2, 3]] -> ['0.00001', ['1', '2', '3']]
+    const rawLossless = LosslessJSON.parse(rawMsg, (key, value) => {
+      if (value && value.isLosslessNumber) {
+        return value.toString()
+      }
+      else {
+        return value;
+      }
+    })
+    const losslessUpdate = rawLossless[1]
     // Snapshot, new OB. Note that we don't protect against duplicates, as they
     // could come in on re-sub
     if (Array.isArray(data[0])) {
       this._orderBooks[symbol] = data
+      this._losslessOrderBooks[symbol] = losslessUpdate
       return null
     }
 
@@ -724,7 +742,7 @@ class WSv2 extends EventEmitter {
     }
 
     OrderBook.updateArrayOBWith(this._orderBooks[symbol], data, raw)
-
+    OrderBook.updateArrayOBWith(this._losslessOrderBooks[symbol], losslessUpdate, raw)
     return null
   }
 
@@ -735,7 +753,7 @@ class WSv2 extends EventEmitter {
    * @return {Error} err - null if none
    */
   _verifyManagedOBChecksum (symbol, prec, cs) {
-    const ob = this._orderBooks[symbol]
+    const ob = this._losslessOrderBooks[symbol]
 
     if (!ob) return null
 
@@ -760,6 +778,21 @@ class WSv2 extends EventEmitter {
     if (!this._orderBooks[symbol]) return null
 
     return new OrderBook(this._orderBooks[symbol])
+  }
+
+  /**
+   * Returns an up-to-date lossless copy of the order book for the specified symbol, or
+   * null if no OB is managed for that symbol. All amounts and prices are in original
+   * string format.
+   * Set `manageOrderBooks: true` in the constructor to use.
+   *
+   * @param {string} symbol
+   * @return {OrderBook} ob - null if not found
+   */
+  getLosslessOB (symbol) {
+    if (!this._losslessOrderBooks[symbol]) return null
+
+    return new OrderBook(this._losslessOrderBooks[symbol])
   }
 
   /**
@@ -1045,9 +1078,10 @@ class WSv2 extends EventEmitter {
 
   /**
    * @param {Object} msg
+   * @param {string} rawMsg
    * @private
    */
-  _handleEventMessage (msg) {
+  _handleEventMessage (msg, rawMsg) {
     if (msg.event === 'auth') {
       return this._handleAuthEvent(msg)
     } else if (msg.event === 'subscribed') {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "debug": "^2.2.0",
     "lodash": "^4.17.4",
     "lodash.throttle": "^4.1.1",
+    "lossless-json": "^1.0.3",
     "p-iteration": "^1.1.8",
     "promise-throttle": "^1.0.1",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
This pull request maintains a lossless string copy of the orderbook for use when generating the checksum string to avoid any nasty floating point precision errors.

### Breaking changes:
- None

### New features:
- [x] function `getLosslessOrderbook`

### Fixes:
- [x] Issue: https://github.com/bitfinexcom/bitfinex-api-node/issues/511

### Depends on:
- https://github.com/bitfinexcom/bfx-api-node-models/pull/33

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
