### PR TITLE
Feature: Auth Arg Management 4.0.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 - WSv2: add updateAthArgs()
 - WSv2: add getAuthArgs()
 - WS2Manager: fix auth args handling with new methods
+- WS2Manager: rename setAuthCredentials -> setAPICredentials
 
 4.0.4
 - Orderbook: generate and update book using lossless string format

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+4.0.5
+- WSv2: add auth arg management (pre-set dms and calc)
+- WSv2: add updateAthArgs()
+- WSv2: add getAuthArgs()
+- WS2Manager: fix auth args handling with new methods
+
 4.0.4
 - Orderbook: generate and update book using lossless string format
   in order to prevent floating point precision checksum errors:

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -12,6 +12,7 @@ const _isString = require('lodash/isString')
 const _includes = require('lodash/includes')
 const _pick = require('lodash/pick')
 const _isEqual = require('lodash/isEqual')
+const _isFinite = require('lodash/isFinite')
 const { genAuthSig, nonce } = require('bfx-api-node-util')
 const getMessagePayload = require('../util/ws2')
 const LosslessJSON = require('lossless-json')
@@ -107,6 +108,7 @@ class WSv2 extends EventEmitter {
     this._orderBooks = {}
     this._losslessOrderBooks = {}
     this._candles = {}
+    this._authArgs = {}
 
     /**
      * {
@@ -142,6 +144,17 @@ class WSv2 extends EventEmitter {
     this._onWSMessage = this._onWSMessage.bind(this)
     this._triggerPacketWD = this._triggerPacketWD.bind(this)
     this._sendCalc = _Throttle(this._sendCalc.bind(this), 1000 / MAX_CALC_OPS)
+  }
+
+  updateAuthArgs (args = {}) {
+    this._authArgs = {
+      ...this._authArgs,
+      ...args
+    }
+  }
+
+  getAuthArgs () {
+    return this._authArgs
   }
 
   setAPICredentials (apiKey, apiSecret) {
@@ -259,7 +272,7 @@ class WSv2 extends EventEmitter {
    * @param {number?} dms - optional dead man switch flag, active 4
    * @return {Promise} p
    */
-  auth (calc = 0, dms = 0) {
+  auth (calc, dms) {
     if (!this._isOpen) return Promise.reject(new Error('not open'))
     if (this._isAuthenticated) {
       return Promise.reject(new Error('already authenticated'))
@@ -268,6 +281,10 @@ class WSv2 extends EventEmitter {
     const authNonce = nonce()
     const authPayload = `AUTH${authNonce}${authNonce}`
     const { sig } = genAuthSig(this._apiSecret, authPayload)
+    const authArgs = { ...this._authArgs }
+
+    if (_isFinite(calc)) authArgs.calc = calc
+    if (_isFinite(dms)) authArgs.dms = dms
 
     return new Promise((resolve, reject) => {
       this.once('auth', () => {
@@ -281,8 +298,7 @@ class WSv2 extends EventEmitter {
         authSig: sig,
         authPayload,
         authNonce,
-        dms,
-        calc
+        ...authArgs
       })
     })
   }

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -51,6 +51,8 @@ class WS2Manager extends EventEmitter {
       ...this._authArgs,
       ...args
     }
+
+    this._sockets.forEach(socket => socket.ws.updateAuthArgs(this._authArgs))
   }
 
   /**
@@ -127,7 +129,8 @@ class WS2Manager extends EventEmitter {
     this._sockets.forEach(s => {
       if (!s.ws.isAuthenticated()) {
         s.ws.setAuthCredentials(apiKey, apiSecret)
-        s.ws.auth({ calc, dms })
+        s.ws.updateAuthArgs(this._authArgs)
+        s.ws.auth()
       }
     })
   }
@@ -141,7 +144,6 @@ class WS2Manager extends EventEmitter {
    */
   openSocket () {
     const { apiKey, apiSecret } = this._socketArgs
-    const { calc, dms } = this._authArgs
     const ws = new WSv2(this._socketArgs)
     const wsState = {
       pendingSubscriptions: [],
@@ -149,6 +151,7 @@ class WS2Manager extends EventEmitter {
       ws
     }
 
+    ws.updateAuthArgs(this._authArgs)
     ws.on('open', () => this.emit('open', ws))
     ws.on('message', (msg = {}) => this.emit('message', msg, ws))
     ws.on('error', (error) => this.emit('error', error, ws))
@@ -194,7 +197,7 @@ class WS2Manager extends EventEmitter {
       ws.once('open', () => {
         debug('authenticating socket...')
 
-        ws.auth(calc, dms).then(() => {
+        ws.auth().then(() => {
           debug('socket authenticated')
         }).catch((err) => {
           debug('error authenticating socket: %s', err.message)

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -128,7 +128,7 @@ class WS2Manager extends EventEmitter {
 
     this._sockets.forEach(s => {
       if (!s.ws.isAuthenticated()) {
-        s.ws.setAuthCredentials(apiKey, apiSecret)
+        s.ws.setAPICredentials(apiKey, apiSecret)
         s.ws.updateAuthArgs(this._authArgs)
         s.ws.auth()
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -51,17 +51,16 @@ describe('WS2Manager', () => {
       m._sockets = [{
         ws: {
           isAuthenticated: () => false,
-          setAuthCredentials: (key, secret) => { cred = `${key}:${secret}` },
-          auth: ({ calc, dms }) => {
-            assert.strictEqual(calc, 1)
-            assert.strictEqual(dms, 4)
+          setAPICredentials: (key, secret) => { cred = `${key}:${secret}` },
+          updateAuthArgs: () => {},
+          auth: () => {
             assert.strictEqual(cred, '41:42')
             done()
           }
         }
       }]
 
-      m.auth({ apiKey: '41', apiSecret: '42', calc: 1, dms: 4 })
+      m.auth({ apiKey: '41', apiSecret: '42' })
     })
   })
 


### PR DESCRIPTION
### Description:
Adds `updateAuthArgs()` and `getAuthArgs()`, along with an internal `_authArgs` map. The map is used within `auth()` to provide `calc` and `dms` defaults.

### New features:
- [x] `WSv2.updateAuthArgs()`
- [x] `WSv2.getAuthArgs()`

### Fixes:
- [x] WS2Manager auth arg handling
- [x] WS2Manager rename setAuthCredentials -> setAPICredentials

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
