### PR TITLE
Fix: 'invalid pub seq #' after submitting an order

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+4.0.6
+- WSv2: fix error 'invalid pub seq #' after submitting an order
+- docs: fix reference link for onAccountTradeEntry
+
 4.0.5
 - WSv2: add auth arg management (pre-set dms and calc)
 - WSv2: add updateAthArgs()

--- a/docs/ws2.md
+++ b/docs/ws2.md
@@ -697,7 +697,7 @@ received.
 
 ### wSv2.onAccountTradeEntry(opts, cb)
 **Kind**: instance method of [<code>WSv2</code>](#WSv2)  
-**See**: https://docs.bitfinex.com/v2/reference#ws-public-trades  
+**See**: https://docs.bitfinex.com/v2/reference#ws-auth-trades  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -353,7 +353,7 @@ class WSv2 extends EventEmitter {
     const seq = (
       (msg[0] === 0) &&
       (msg[1] !== 'hb') &&
-      !(msg[1] === 'n' && msg[2][1] === 'oc-req')
+      !(msg[1] === 'n' && (msg[2][1] === 'oc-req' || msg[2][1] === 'on-req'))
     )
       ? msg[msg.length - 2]
       : msg[msg.length - 1]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Fixes error 'invalid pub seq #' after submitting an order ( see issue #519)

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] WSv2: Error `invalid pub seq #` after submitting an order #519
- [x] docs: reference link for `onAccountTradeEntry`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
