### PR TITLE
Fix: Flag Persistence 4.0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.6
+- WSv2: fix internal flag persistence #521
+
 4.0.5
 - WSv2: add auth arg management (pre-set dms and calc)
 - WSv2: add updateAthArgs()

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -127,7 +127,7 @@ class WSv2 extends EventEmitter {
     this._subscriptionRefs = {}
     this._channelMap = {}
     this._orderBooks = {}
-    this._enabledFlags = 0
+    this._enabledFlags = this._seqAudit ? FLAGS.SEQ_ALL : 0
     this._eventCallbacks = new CbQ()
     this._isAuthenticated = false
     this._wasEverAuthenticated = false // used for auto-auth on reconnect
@@ -214,16 +214,19 @@ class WSv2 extends EventEmitter {
     this._orderBooks = {}
 
     this._ws.on('message', this._onWSMessage)
-    this._ws.on('open', this._onWSOpen)
     this._ws.on('error', this._onWSError)
     this._ws.on('close', this._onWSClose)
 
-    if (this._seqAudit) {
-      this._ws.once('open', this.enableSequencing.bind(this))
-    }
-
     return new Promise((resolve, reject) => {
-      this._ws.once('open', () => {
+      this._ws.on('open', () => {
+        if (this._enabledFlags !== 0) {
+          this.sendEnabledFlags()
+        }
+
+        // call manually instead of binding to open event so it fires at the
+        // right time
+        this._onWSOpen()
+
         debug('connected')
         resolve()
       })
@@ -468,7 +471,6 @@ class WSv2 extends EventEmitter {
     this._isOpen = true
     this._isReconnecting = false
     this._packetWDLastTS = Date.now()
-    this._enabledFlags = 0
     this._lastAuthSeq = -1
     this._lastPubSeq = -1
     this.emit('open')
@@ -1382,12 +1384,24 @@ class WSv2 extends EventEmitter {
    * @return {Promise} p
    */
   enableFlag (flag) {
+    this._enabledFlags = this._enabledFlags | flag
+
+    if (this._isOpen) {
+      this.sendEnabledFlags()
+      return this._getEventPromise(this._getConfigEventKey(flag))
+    }
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Sends the local flags value to the server, updating the config
+   */
+  sendEnabledFlags () {
     this.send({
       event: 'conf',
-      flags: this._enabledFlags | flag
+      flags: this._enabledFlags
     })
-
-    return this._getEventPromise(this._getConfigEventKey(flag))
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Previously the internal `_enabledFlags` value was not being correctly updated based on the state of `seqAudit` in the constructor or subsequent changes.

This fixes it + associated tests, closes #521 

### Fixes:
- [x] internal flags persistence/tracking

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Documentation updated
