### PR TITLE
Refactor: Use async/await where possible in tests/ws2 4.0.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+4.0.7
+- WSv2: refactor to use async/await style where possible
+- WSv2: reconnect() now always resolves on completion
+
 4.0.6
 - WSv2: fix internal flag persistence #521
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -198,9 +198,9 @@ class WSv2 extends EventEmitter {
    *
    * @return {Promise} p
    */
-  open () {
+  async open () {
     if (this._isOpen || this._ws !== null) {
-      return Promise.reject(new Error('already open'))
+      throw new Error('already open')
     }
 
     debug('connecting to %s...', this._url)
@@ -219,13 +219,13 @@ class WSv2 extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this._ws.on('open', () => {
-        if (this._enabledFlags !== 0) {
-          this.sendEnabledFlags()
-        }
-
         // call manually instead of binding to open event so it fires at the
         // right time
         this._onWSOpen()
+
+        if (this._enabledFlags !== 0) {
+          this.sendEnabledFlags()
+        }
 
         debug('connected')
         resolve()
@@ -239,16 +239,16 @@ class WSv2 extends EventEmitter {
    *
    * @param {number} code - passed to ws
    * @param {string} reason - passed to ws
-   * @return {Promise}
+   * @return {Promise} p
    */
-  close (code, reason) {
+  async close (code, reason) {
     if (!this._isOpen || this._ws === null) {
-      return Promise.reject(new Error('not open'))
+      throw new Error('not open')
     }
 
     debug('disconnecting...')
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this._ws.once('close', () => {
         this._isOpen = false
         this._ws = null
@@ -275,10 +275,13 @@ class WSv2 extends EventEmitter {
    * @param {number?} dms - optional dead man switch flag, active 4
    * @return {Promise} p
    */
-  auth (calc, dms) {
-    if (!this._isOpen) return Promise.reject(new Error('not open'))
+  async auth (calc, dms) {
+    if (!this._isOpen) {
+      throw new Error('not open')
+    }
+
     if (this._isAuthenticated) {
-      return Promise.reject(new Error('already authenticated'))
+      throw new Error('already authenticated')
     }
 
     const authNonce = nonce()
@@ -289,7 +292,7 @@ class WSv2 extends EventEmitter {
     if (_isFinite(calc)) authArgs.calc = calc
     if (_isFinite(dms)) authArgs.dms = dms
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.once('auth', () => {
         debug('authenticated')
         resolve()
@@ -317,6 +320,10 @@ class WSv2 extends EventEmitter {
 
     if (this._ws !== null && this._isOpen) { // did we get a watchdog timeout and need to close the connection?
       await this.close()
+
+      return new Promise((resolve) => {
+        this.once(this._wasEverAuthenticated ? 'auth' : 'open', resolve)
+      })
     } else {
       await this.reconnectAfterClose() // we are already closed, so reopen and re-auth
     }
@@ -393,11 +400,13 @@ class WSv2 extends EventEmitter {
   /**
    * Trigger the packet watch-dog; called when we haven't seen a new WS packet
    * for longer than our WD duration (if provided)
+   *
+   * @return {Promise} p
    * @private
    */
-  _triggerPacketWD () {
+  async _triggerPacketWD () {
     if (!this._packetWDDelay || !this._isOpen) {
-      return Promise.resolve()
+      return
     }
 
     debug(
@@ -429,6 +438,9 @@ class WSv2 extends EventEmitter {
     }, this._packetWDDelay)
   }
 
+  /**
+   * Subscribes to previously subscribed channels, used after reconnecting
+   */
   resubscribePreviousChannels () {
     Object.values(this._prevChannelMap).forEach((chan) => {
       const { channel } = chan
@@ -458,7 +470,9 @@ class WSv2 extends EventEmitter {
           break
         }
 
-        default: {}
+        default: {
+          debug('unknown previously subscribed channel type: %s', channel)
+        }
       }
     })
   }
@@ -486,7 +500,7 @@ class WSv2 extends EventEmitter {
   /**
    * @private
    */
-  _onWSClose () {
+  async _onWSClose () {
     this._isOpen = false
     this._isAuthenticated = false
     this._lastAuthSeq = -1
@@ -504,17 +518,15 @@ class WSv2 extends EventEmitter {
     if (this._isReconnecting || (this._autoReconnect && !this._isClosing)) {
       this._prevChannelMap = this._channelMap
 
-      setTimeout(() => {
-        if (this._reconnectThrottler) {
-          this._reconnectThrottler
-            .add(this.reconnectAfterClose.bind(this))
-            .catch((err) => {
-              debug('error reconnectAfterClose: %s', err.stack)
-            })
-        } else {
-          this.reconnectAfterClose().catch((err) => {
-            debug('error reconnectAfterClose: %s', err.stack)
-          })
+      setTimeout(async () => {
+        try {
+          if (this._reconnectThrottler) {
+            await this._reconnectThrottler.add(this.reconnectAfterClose.bind(this))
+          } else {
+            await this.reconnectAfterClose()
+          }
+        } catch (err) {
+          debug('error reconnectAfterClose: %s', err.stack)
         }
       }, this._reconnectDelay)
     }
@@ -1371,7 +1383,7 @@ class WSv2 extends EventEmitter {
    * @param {boolean} args.audit - if true, an error is emitted on invalid seq
    * @return {Promise} p
    */
-  enableSequencing (args = { audit: true }) {
+  async enableSequencing (args = { audit: true }) {
     this._seqAudit = args.audit === true
 
     return this.enableFlag(FLAGS.SEQ_ALL)
@@ -1588,9 +1600,9 @@ class WSv2 extends EventEmitter {
    * @param {Object|Array} order
    * @return {Promise} p - resolves on submit notification
    */
-  submitOrder (order) {
+  async submitOrder (order) {
     if (!this._isAuthenticated) {
-      return Promise.reject(new Error('not authenticated'))
+      throw new Error('not authenticated')
     }
 
     const packet = Array.isArray(order)
@@ -1620,13 +1632,13 @@ class WSv2 extends EventEmitter {
    * @param {Object} changes - requires at least an 'id'
    * @return {Promise} p - resolves on receival of confirmation notification
    */
-  updateOrder (changes = {}) {
+  async updateOrder (changes = {}) {
     const { id } = changes
 
     if (!this._isAuthenticated) {
-      return Promise.reject(new Error('not authenticated'))
+      throw new Error('not authenticated')
     } else if (!id) {
-      return Promise.reject(new Error('order ID required for update'))
+      throw new Error('order ID required for update')
     }
 
     this._sendOrderPacket([0, 'ou', null, changes])
@@ -1642,9 +1654,9 @@ class WSv2 extends EventEmitter {
    * @param {Object|Array|number} order
    * @return {Promise} p
    */
-  cancelOrder (order) {
+  async cancelOrder (order) {
     if (!this._isAuthenticated) {
-      return Promise.reject(new Error('not authenticated'))
+      throw new Error('not authenticated')
     }
 
     const id = typeof order === 'number'
@@ -1668,14 +1680,12 @@ class WSv2 extends EventEmitter {
    * @param {Object[]|Array[]|number[]} orders
    * @return {Promise} p
    */
-  cancelOrders (orders) {
+  async cancelOrders (orders) {
     if (!this._isAuthenticated) {
-      return Promise.reject(new Error('not authenticated'))
+      throw new Error('not authenticated')
     }
 
-    return Promise.all(orders.map((order) => {
-      return this.cancelOrder(order)
-    }))
+    return Promise.all(orders.map(this.cancelOrder))
   }
 
   /**
@@ -1686,14 +1696,13 @@ class WSv2 extends EventEmitter {
    * @param {Object[]} opPayloads
    * @return {Promise} p - rejects if not authenticated
    */
-  submitOrderMultiOp (opPayloads) {
+  async submitOrderMultiOp (opPayloads) {
     if (!this._isAuthenticated) {
-      return Promise.reject(new Error('not authenticated'))
+      throw new Error('not authenticated')
     }
 
+    // TODO: multi-op tracking
     this.send([0, 'ox_multi', null, opPayloads])
-
-    return Promise.resolve() // TODO: multi-op tracking
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Updates a few methods in WSv2 and several tests to use async/await instead of waiting for the `open` or `auth` events. Quality of life improvement, makes the tests far easier to follow.

Needs to be merged after/will have minor conflicts with https://github.com/bitfinexcom/bitfinex-api-node/pull/522 (4.0.6)

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
