### PR TITLE
Bug/wsv2 trade filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.8
+- WSv2: fix on trade message handler by prioritising channel data symbol over pair symbol
+
 4.0.7
 - WSv2: refactor to use async/await style where possible
 - WSv2: reconnect() now always resolves on completion

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -848,10 +848,10 @@ class WSv2 extends EventEmitter {
         : PublicTrade.unserialize(payload)
 
     const internalMessage = [chanData.chanId, eventName, data]
-    internalMessage.filterOverride = [chanData.pair || chanData.symbol]
+    internalMessage.filterOverride = [chanData.symbol || chanData.pair]
 
     this._propagateMessageToListeners(internalMessage, chanData, false)
-    this.emit('trades', chanData.pair || chanData.symbol, data)
+    this.emit('trades', chanData.symbol || chanData.pair, data)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
On trade message handler didn't propagate messages to attached onTrades listeners since there was a mismatch between channel symbol and received pair (e.g. `tBTCUSD` != `BTCUSD`). Prioritizing channel symbol instead of trading pair solved the issue since the payload filter matches the subscribed symbol (https://github.com/bitfinexcom/bitfinex-api-node/blob/master/lib/transports/ws2.js#L1086). Closes issue [517](https://github.com/bitfinexcom/bitfinex-api-node/issues/517)

### Breaking changes:
- [x] subscribing to symbols like `BTCUSD` instead of `tBTCUSD` doesn't propagate messages

### Fixes:
- [x] messages didn't propagate to attached onTrades listeners

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
