### PR TITLE
Fix: Respect internal auth arg settings in WS2Manager 4.0.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.9
+- WS2Manager: respect internal auth arg settings
+
 4.0.8
 - WSv2: fix on trade message handler by prioritising channel data symbol over pair symbol
 

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -124,7 +124,11 @@ class WS2Manager extends EventEmitter {
 
     this._socketArgs.apiKey = apiKey
     this._socketArgs.apiSecret = apiSecret
-    this._authArgs = { calc, dms }
+    this._authArgs = {
+      ...this._authArgs,
+      calc,
+      dms,
+    }
 
     this._sockets.forEach(s => {
       if (!s.ws.isAuthenticated()) {

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -3,6 +3,7 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('bfx:ws2:manager')
 const _isEqual = require('lodash/isEqual')
+const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
 const _pick = require('lodash/pick')
 const PromiseThrottle = require('promise-throttle')
@@ -116,7 +117,7 @@ class WS2Manager extends EventEmitter {
    * @param {Object?} args.calc - default 0
    * @param {Object?} args.dms - dead man switch, active 4
    */
-  auth ({ apiKey, apiSecret, calc = 0, dms = 0 } = {}) {
+  auth ({ apiKey, apiSecret, calc, dms } = {}) {
     if (this._socketArgs.apiKey || this._socketArgs.apiSecret) {
       debug('error: auth credentials already provided! refusing auth')
       return
@@ -124,11 +125,9 @@ class WS2Manager extends EventEmitter {
 
     this._socketArgs.apiKey = apiKey
     this._socketArgs.apiSecret = apiSecret
-    this._authArgs = {
-      ...this._authArgs,
-      calc,
-      dms,
-    }
+
+    if (_isFinite(calc)) this._authArgs.calc = calc
+    if (_isFinite(dms)) this._authArgs.dms = dms
 
     this._sockets.forEach(s => {
       if (!s.ws.isAuthenticated()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
`WS2Manager` was overwriting internal auth args on each call to `auth()`, which provided default `dms` and `calc` params.

### Fixes:
- [x] WS2Manager now respects internal `dms` and `calc` if not provided to `auth()`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
