### PR TITLE
Fix: Concurrent tests 4.0.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ todo
 package-lock.json
 .env
 dist/
+.nyc_output
+coverage/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.10
+- fix: refactor tests so they can run alongside all other HF/API library tests
+
 4.0.9
 - WS2Manager: respect internal auth arg settings
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 A Node.JS reference implementation of the Bitfinex API
 
-### Features
+## Features
 
 * Official implementation
 * REST v2 API
 * WebSockets v2 API
 * WebSockets v1 API
 
-
 ## Installation
+
 ```bash
   npm i --save bitfinex-api-node
 ```
@@ -35,6 +35,7 @@ Official API documentation at [https://docs.bitfinex.com/v2/reference](https://d
 ### Examples
 
 Sending an order & tracking status:
+
 ```js
 const ws = bfx.ws()
 
@@ -73,6 +74,7 @@ ws.open()
 ```
 
 Cancel all open orders
+
 ```js
 const ws = bfx.ws(2)
 
@@ -96,6 +98,7 @@ ws.open()
 ```
 
 Subscribe to trades by pair
+
 ```js
 const ws = bfx.ws(2)
 
@@ -114,9 +117,9 @@ ws.onTradeEntry({ symbol: 'tBTCUSD' }, (trades) => {
 ws.open()
 ```
 
-## Version 2.0.0 Breaking changes:
+## Version 2.0.0 Breaking changes
 
-### constructor takes only an options object now, including the API keys.
+### constructor takes only an options object now, including the API keys
 
 Old:
 

--- a/examples/rest2/order-history.js
+++ b/examples/rest2/order-history.js
@@ -16,7 +16,6 @@ const rest = bfx.rest(2, { transform: true })
 const pair = String(args[2])
 const symbol = pair[0] === 't' ? pair : `t${pair}`
 
-// TODO: natural lang start/end query args (a library must exist)
 const START = Date.now() - (30 * 24 * 60 * 60 * 1000 * 1000)
 const END = Date.now()
 const LIMIT = 25

--- a/examples/rest2/trade-history.js
+++ b/examples/rest2/trade-history.js
@@ -16,7 +16,6 @@ const rest = bfx.rest(2, { transform: true })
 const pair = String(args[2])
 const symbol = pair[0] === 't' ? pair : `t${pair}`
 
-// TODO: natural lang start/end query args (a library must exist)
 const START = Date.now() - (30 * 24 * 60 * 60 * 1000 * 1000)
 const END = Date.now()
 const LIMIT = 25

--- a/examples/ws2/notifications.js
+++ b/examples/ws2/notifications.js
@@ -1,0 +1,29 @@
+'use strict'
+
+process.env.DEBUG = 'bfx:examples:notifications'
+
+const debug = require('debug')('bfx:examples:notifications')
+const bfx = require('../bfx')
+const ws = bfx.ws(2)
+
+const run = async () => {
+  ws.on('error', (err) => {
+    debug('error: %s', err instanceof Error ? err.stack : err)
+  })
+
+  ws.onNotification({ type: '*' }, (n) => {
+    debug('recv notification: %j', n)
+  })
+
+  debug('connecting...')
+  await ws.open()
+  debug('connected')
+  await ws.auth()
+  debug('authenticated, listening for notifications')
+}
+
+try {
+  run()
+} catch (e) {
+  console.log(`error: ${e.stack}`)
+}

--- a/index.js
+++ b/index.js
@@ -48,14 +48,20 @@ class BFX {
     }
   }
 
+  /**
+   * Returns an arguments map ready to pass to a transport constructor
+   *
+   * @param {Object} extraOpts - options to pass to transport
+   */
   _getTransportPayload (extraOpts) {
-    return Object.assign({
+    return {
       apiKey: this._apiKey,
       apiSecret: this._apiSecret,
       authToken: this._authToken,
       company: this._company,
-      transform: this._transform
-    }, extraOpts)
+      transform: this._transform,
+      ...extraOpts
+    }
   }
 
   /**

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -481,7 +481,6 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _onWSOpen () {
-    // TODO: Add _resetState() method for this, see _onWSClose
     this._isOpen = true
     this._isReconnecting = false
     this._packetWDLastTS = Date.now()
@@ -640,7 +639,7 @@ class WSv2 extends EventEmitter {
     }
 
     if (msg.length < 2) return
-    if (msg[1] === 'hb') return // TODO: optionally track seq
+    if (msg[1] === 'hb') return
 
     if (channelData.channel === 'book') {
       if (type === 'cs') {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "bfx-api-mock-srv": "^1.0.0",
+    "bfx-api-mock-srv": "^1.0.4",
     "chai": "^3.4.1",
     "cli-table2": "^0.2.0",
     "dotenv": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=7"

--- a/package.json
+++ b/package.json
@@ -52,15 +52,16 @@
   },
   "homepage": "http://bitfinexcom.github.io/bitfinex-api-node/",
   "devDependencies": {
-    "bfx-api-mock-srv": "^1.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "bfx-api-mock-srv": "^1.0.0",
     "chai": "^3.4.1",
     "cli-table2": "^0.2.0",
     "dotenv": "^4.0.0",
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^3.4.2",
+    "nyc": "^15.0.0",
     "socks-proxy-agent": "^3.0.1",
     "standard": "^10.0.2"
   },

--- a/test/lib/transports/ws2-integration.js
+++ b/test/lib/transports/ws2-integration.js
@@ -24,83 +24,99 @@ const createTestWSv2Instance = (params = {}) => {
   })
 }
 
-describe('WSv2 orders', () => {
-  it('creates & confirms orders', async () => {
-    const wss = new MockWSv2Server({ listen: true })
-    const ws = createTestWSv2Instance()
+describe('WSv2 integration', () => {
+  let ws = null
+  let wss = null
 
-    await ws.open()
-    await ws.auth()
+  afterEach(async () => {
+    try { // may fail due to being modified by a test, it's not a problem
+      if (ws && ws.isOpen()) {
+        await ws.close()
+      }
+    } catch (e) {}
 
-    const o = new Order({
-      gid: null,
-      cid: 0,
-      type: 'EXCHANGE LIMIT',
-      price: 100,
-      amount: 1,
-      symbol: 'tBTCUSD'
-    })
+    if (wss && wss.isOpen()) {
+      await wss.close()
+    }
 
-    return ws.submitOrder(o).then(() => {
-      wss.close()
-    })
+    ws = null
+    wss = null
   })
 
-  it('keeps orders up to date', async () => {
-    const wss = new MockWSv2Server({ listen: true })
-    const ws = createTestWSv2Instance()
+  describe('orders', () => {
+    it('creates & confirms orders', async () => {
+      wss = new MockWSv2Server({ listen: true })
+      ws = createTestWSv2Instance()
 
-    await ws.open()
-    await ws.auth()
+      await ws.open()
+      await ws.auth()
 
-    const o = new Order({
-      gid: null,
-      cid: 0,
-      type: 'EXCHANGE LIMIT',
-      price: 100,
-      amount: 1,
-      symbol: 'tBTCUSD'
-    }, ws)
+      const o = new Order({
+        gid: null,
+        cid: 0,
+        type: 'EXCHANGE LIMIT',
+        price: 100,
+        amount: 1,
+        symbol: 'tBTCUSD'
+      })
 
-    o.registerListeners()
+      return ws.submitOrder(o)
+    })
 
-    await o.submit()
+    it('keeps orders up to date', async () => {
+      wss = new MockWSv2Server({ listen: true })
+      ws = createTestWSv2Instance()
 
-    const arr = o.serialize()
-    arr[16] = 256
+      await ws.open()
+      await ws.auth()
 
-    wss.send([0, 'ou', arr])
+      const o = new Order({
+        gid: null,
+        cid: 0,
+        type: 'EXCHANGE LIMIT',
+        price: 100,
+        amount: 1,
+        symbol: 'tBTCUSD'
+      }, ws)
 
-    await delay(100)
+      o.registerListeners()
 
-    assert.strictEqual(o.price, 256)
-    arr[16] = 150
+      await o.submit()
 
-    wss.send([0, 'oc', arr])
+      const arr = o.serialize()
+      arr[16] = 256
 
-    await delay(100)
+      wss.send([0, 'ou', arr])
 
-    assert.strictEqual(o.price, 150)
-    o.removeListeners()
-    wss.close()
-  })
+      await delay(100)
 
-  it('updateOrder: sends order changeset packet through', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
+      assert.strictEqual(o.price, 256)
+      arr[16] = 150
 
-    await ws.open()
-    await ws.auth()
+      wss.send([0, 'oc', arr])
 
-    const o = new Order({
-      id: Date.now(),
-      type: 'EXCHANGE LIMIT',
-      price: 100,
-      amount: 1,
-      symbol: 'tBTCUSD'
-    }, ws)
+      await delay(100)
 
-    return new Promise((resolve) => {
+      assert.strictEqual(o.price, 150)
+      o.removeListeners()
+    })
+
+    it('updateOrder: sends order changeset packet through', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+      await ws.auth()
+
+      let sawMessage = false
+      const o = new Order({
+        id: Date.now(),
+        type: 'EXCHANGE LIMIT',
+        price: 100,
+        amount: 1,
+        symbol: 'tBTCUSD'
+      }, ws)
+
       ws._ws.send = (msgJSON) => {
         const msg = JSON.parse(msgJSON)
 
@@ -111,191 +127,193 @@ describe('WSv2 orders', () => {
         assert.strictEqual(+msg[3].delta, 1)
         assert.strictEqual(+msg[3].price, 200)
 
-        wss.close()
-        resolve()
+        sawMessage = true
       }
 
-      o.update({ price: 200, delta: 1 })
-    })
-  })
-
-  it('sends individual order packets when not buffering', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-    await ws.auth()
-
-    const oA = new Order({
-      gid: null,
-      cid: Date.now(),
-      type: 'EXCHANGE LIMIT',
-      price: 100,
-      amount: 1,
-      symbol: 'tBTCUSD'
+      o.update({ price: 200, delta: 1 }) // note promise ignored
+      assert(sawMessage)
     })
 
-    const oB = new Order({
-      gid: null,
-      cid: Date.now(),
-      type: 'EXCHANGE LIMIT',
-      price: 10,
-      amount: 1,
-      symbol: 'tETHUSD'
-    })
+    it('sends individual order packets when not buffering', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
 
-    let sendN = 0
+      await ws.open()
+      await ws.auth()
 
-    return new Promise(async (resolve) => {
+      let sawBothOrders = false
+      const oA = new Order({
+        gid: null,
+        cid: Date.now(),
+        type: 'EXCHANGE LIMIT',
+        price: 100,
+        amount: 1,
+        symbol: 'tBTCUSD'
+      })
+
+      const oB = new Order({
+        gid: null,
+        cid: Date.now(),
+        type: 'EXCHANGE LIMIT',
+        price: 10,
+        amount: 1,
+        symbol: 'tETHUSD'
+      })
+
+      let sendN = 0
+
       ws._ws.send = (msgJSON) => {
         const msg = JSON.parse(msgJSON)
         assert.strictEqual(msg[1], 'on')
         sendN++
 
         if (sendN === 2) {
-          wss.close()
-          resolve()
+          sawBothOrders = true
         }
       }
 
       // note promises ignored
       ws.submitOrder(oA)
       ws.submitOrder(oB)
-    })
-  })
 
-  it('buffers order packets', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance({
-      orderOpBufferDelay: 100
+      assert(sawBothOrders)
     })
 
-    await ws.open()
-    await ws.auth()
+    it('buffers order packets', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance({
+        orderOpBufferDelay: 100
+      })
 
-    const oA = new Order({
-      gid: null,
-      cid: Date.now(),
-      type: 'EXCHANGE LIMIT',
-      price: 100,
-      amount: 1,
-      symbol: 'tBTCUSD'
-    })
+      await ws.open()
+      await ws.auth()
 
-    const oB = new Order({
-      gid: null,
-      cid: Date.now(),
-      type: 'EXCHANGE LIMIT',
-      price: 10,
-      amount: 1,
-      symbol: 'tETHUSD'
-    })
+      const oA = new Order({
+        gid: null,
+        cid: Date.now(),
+        type: 'EXCHANGE LIMIT',
+        price: 100,
+        amount: 1,
+        symbol: 'tBTCUSD'
+      })
 
-    return new Promise(async (resolve) => {
-      ws._ws.send = (msgJSON) => {
-        const msg = JSON.parse(msgJSON)
-        assert.strictEqual(msg[1], 'ox_multi')
+      const oB = new Order({
+        gid: null,
+        cid: Date.now(),
+        type: 'EXCHANGE LIMIT',
+        price: 10,
+        amount: 1,
+        symbol: 'tETHUSD'
+      })
 
-        msg[3].forEach((payload) => {
-          assert.strictEqual(payload[0], 'on')
-        })
+      return new Promise((resolve) => {
+        ws._ws.send = (msgJSON) => {
+          const msg = JSON.parse(msgJSON)
+          assert.strictEqual(msg[1], 'ox_multi')
 
-        wss.close()
-        resolve()
-      }
+          msg[3].forEach((payload) => {
+            assert.strictEqual(payload[0], 'on')
+          })
 
-      // note promises ignored
-      ws.submitOrder(oA)
-      ws.submitOrder(oB)
-    })
-  })
-})
+          wss.close()
+          resolve()
+        }
 
-describe('WSv2 listeners', () => {
-  it('manages listeners by cbGID', () => {
-    const ws = createTestWSv2Instance()
-    ws._channelMap = { 0: { channel: 'auth' } }
-
-    let updatesSeen = 0
-    ws.onAccountTradeUpdate({ pair: 'BTCUSD', cbGID: 10 }, () => updatesSeen++)
-    ws.onOrderUpdate({ symbol: 'tBTCUSD', cbGID: 10 }, () => updatesSeen++)
-
-    ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
-    ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
-    ws.removeListeners(10)
-    ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
-    ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
-
-    assert.strictEqual(updatesSeen, 2)
-  })
-
-  it('tracks channel refs to auto sub/unsub', async () => {
-    const ws = createTestWSv2Instance()
-    const wss = new MockWSv2Server()
-    let subs = 0
-    let unsubs = 0
-
-    await ws.open()
-
-    wss.on('message', (ws, msg) => {
-      if (msg.event === 'subscribe' && msg.channel === 'trades') {
-        subs++
-        ws.send(JSON.stringify({
-          event: 'subscribed',
-          chanId: 42,
-          channel: 'trades',
-          symbol: msg.symbol
-        }))
-      } else if (msg.event === 'unsubscribe' && msg.chanId === 42) {
-        unsubs++
-        ws.send(JSON.stringify({
-          event: 'unsubscribed',
-          chanId: 42
-        }))
-      }
-    })
-
-    ws.subscribeTrades('tBTCUSD')
-    ws.subscribeTrades('tBTCUSD')
-    ws.subscribeTrades('tBTCUSD')
-
-    ws.on('subscribed', () => {
-      ws.unsubscribeTrades('tBTCUSD')
-      ws.unsubscribeTrades('tBTCUSD')
-      ws.unsubscribeTrades('tBTCUSD')
-      ws.unsubscribeTrades('tBTCUSD')
-      ws.unsubscribeTrades('tBTCUSD')
-    })
-
-    return new Promise((resolve) => {
-      ws.on('unsubscribed', () => {
-        assert.strictEqual(subs, 1)
-        assert.strictEqual(unsubs, 1)
-        wss.close()
-        resolve()
+        // note promises ignored
+        ws.submitOrder(oA)
+        ws.submitOrder(oB)
       })
     })
   })
-})
 
-describe('WSv2 info message handling', () => {
-  it('notifies listeners on matching code', (done) => {
-    const ws = new WSv2()
+  describe('listeners', () => {
+    it('manages listeners by cbGID', () => {
+      ws = createTestWSv2Instance()
+      ws._channelMap = { 0: { channel: 'auth' } }
 
-    ws.onInfoMessage(WSv2.info.MAINTENANCE_END, () => {
-      done()
+      let updatesSeen = 0
+      ws.onAccountTradeUpdate({ pair: 'BTCUSD', cbGID: 10 }, () => updatesSeen++)
+      ws.onOrderUpdate({ symbol: 'tBTCUSD', cbGID: 10 }, () => updatesSeen++)
+
+      ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
+      ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
+      ws.removeListeners(10)
+      ws._handleChannelMessage([0, 'tu', [123, 'tBTCUSD']])
+      ws._handleChannelMessage([0, 'ou', [0, 0, 0, 'tBTCUSD']])
+
+      assert.strictEqual(updatesSeen, 2)
     })
 
-    ws._onWSMessage(JSON.stringify({
-      event: 'info',
-      code: WSv2.info.MAINTENANCE_START,
-      msg: ''
-    }))
+    it('tracks channel refs to auto sub/unsub', async () => {
+      ws = createTestWSv2Instance()
+      wss = new MockWSv2Server()
+      let subs = 0
+      let unsubs = 0
 
-    ws._onWSMessage(JSON.stringify({
-      event: 'info',
-      code: WSv2.info.MAINTENANCE_END,
-      msg: ''
-    }))
+      await ws.open()
+
+      wss.on('message', (ws, msg) => {
+        if (msg.event === 'subscribe' && msg.channel === 'trades') {
+          subs++
+          ws.send(JSON.stringify({
+            event: 'subscribed',
+            chanId: 42,
+            channel: 'trades',
+            symbol: msg.symbol
+          }))
+        } else if (msg.event === 'unsubscribe' && msg.chanId === 42) {
+          unsubs++
+          ws.send(JSON.stringify({
+            event: 'unsubscribed',
+            chanId: 42
+          }))
+        }
+      })
+
+      ws.subscribeTrades('tBTCUSD')
+      ws.subscribeTrades('tBTCUSD')
+      ws.subscribeTrades('tBTCUSD')
+
+      ws.on('subscribed', () => {
+        ws.unsubscribeTrades('tBTCUSD')
+        ws.unsubscribeTrades('tBTCUSD')
+        ws.unsubscribeTrades('tBTCUSD')
+        ws.unsubscribeTrades('tBTCUSD')
+        ws.unsubscribeTrades('tBTCUSD')
+      })
+
+      return new Promise((resolve) => {
+        ws.on('unsubscribed', () => {
+          assert.strictEqual(subs, 1)
+          assert.strictEqual(unsubs, 1)
+          resolve()
+        })
+      })
+    })
+  })
+
+  describe('info message handling', () => {
+    it('notifies listeners on matching code', () => {
+      let sawMaintenanceEnd = false
+      ws = new WSv2()
+
+      ws.onInfoMessage(WSv2.info.MAINTENANCE_END, () => {
+        sawMaintenanceEnd = true
+      })
+
+      ws._onWSMessage(JSON.stringify({
+        event: 'info',
+        code: WSv2.info.MAINTENANCE_START,
+        msg: ''
+      }))
+
+      ws._onWSMessage(JSON.stringify({
+        event: 'info',
+        code: WSv2.info.MAINTENANCE_END,
+        msg: ''
+      }))
+
+      assert(sawMaintenanceEnd)
+    })
   })
 })

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -19,1823 +19,1858 @@ const createTestWSv2Instance = (params = {}) => {
   })
 }
 
-describe('WSv2 utilities', () => {
-  it('sendEnabledFlags: sends the current flags value to the server', async () => {
-    const ws = new WSv2()
-    const wss = new MockWSv2Server()
+describe('WSv2 unit', () => {
+  let ws = null
+  let wss = null
 
-    await ws.open()
+  afterEach(async () => {
+    try { // may fail due to being modified by a test, it's not a problem
+      if (ws && ws.isOpen()) {
+        await ws.close()
+      }
+    } catch (e) {}
 
-    ws._enabledFlags = WSv2.flags.CHECKSUM
-    ws.send = (packet) => {
-      assert.strictEqual(packet.event, 'conf')
-      assert.strictEqual(packet.flags, WSv2.flags.CHECKSUM)
-
-      wss.close()
+    if (wss && wss.isOpen()) {
+      await wss.close()
     }
 
-    ws.sendEnabledFlags()
+    ws = null
+    wss = null
   })
 
-  it('enableFlag: saves enabled flag status', () => {
-    const ws = new WSv2()
+  describe('utilities', () => {
+    it('sendEnabledFlags: sends the current flags value to the server', async () => {
+      ws = createTestWSv2Instance()
+      wss = new MockWSv2Server()
 
-    assert(!ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
-    assert(!ws.isFlagEnabled(WSv2.flags.CHECKSUM))
+      await ws.open()
 
-    ws.enableFlag(WSv2.flags.SEQ_ALL)
+      ws._enabledFlags = WSv2.flags.CHECKSUM
 
-    assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
-    assert(!ws.isFlagEnabled(WSv2.flags.CHECKSUM))
-
-    ws.enableFlag(WSv2.flags.CHECKSUM)
-
-    assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
-    assert(ws.isFlagEnabled(WSv2.flags.CHECKSUM))
-  })
-
-  it('enableFlag: sends conf packet if open', async () => {
-    const ws = new WSv2()
-    const wss = new MockWSv2Server()
-    let confSent = false
-
-    await ws.open()
-
-    ws.send = (packet) => {
-      assert(_isObject(packet))
-      assert.strictEqual(packet.event, 'conf')
-      confSent = true
-
-      wss.close()
-    }
-
-    ws.enableFlag(WSv2.flags.SEQ_ALL)
-    assert(confSent)
-  })
-
-  it('_registerListener: correctly adds listener to internal map with cbGID', () => {
-    const ws = new WSv2()
-    ws._registerListener('trade', { 2: 'tBTCUSD' }, Map, 42, () => {})
-
-    const { _listeners } = ws
-
-    assert.strictEqual(Object.keys(_listeners).length, 1)
-    assert.strictEqual(+Object.keys(_listeners)[0], 42)
-    assert.strictEqual(typeof _listeners[42], 'object')
-
-    const listenerSet = _listeners[42]
-
-    assert.strictEqual(Object.keys(listenerSet).length, 1)
-    assert.strictEqual(Object.keys(listenerSet)[0], 'trade')
-    assert.strictEqual(listenerSet.trade.constructor.name, 'Array')
-    assert.strictEqual(listenerSet.trade.length, 1)
-
-    const listener = listenerSet.trade[0]
-
-    assert.strictEqual(listener.modelClass, Map)
-    assert.deepStrictEqual(listener.filter, { 2: 'tBTCUSD' })
-    assert.strictEqual(typeof listener.cb, 'function')
-  })
-
-  it('enableSequencing: sends the correct conf flag', (done) => {
-    const ws = new WSv2()
-    const wss = new MockWSv2Server()
-
-    ws.once('open', () => {
-      setTimeout(() => { // send is used by the open hander
+      return new Promise((resolve) => {
         ws.send = (packet) => {
           assert.strictEqual(packet.event, 'conf')
-          assert.strictEqual(packet.flags, 65536)
-
-          wss.close()
-          done()
-        }
-
-        ws.enableSequencing()
-      }, 20)
-    })
-
-    ws.open()
-  })
-
-  it('getCandles: returns empty array if no candle set is available', () => {
-    const ws = new WSv2()
-    assert.deepStrictEqual(ws.getCandles('i.dont.exist'), [])
-  })
-
-  it('_sendCalc: stringifes payload & passes it to the ws client', (done) => {
-    const ws = new WSv2()
-
-    ws._ws = {}
-    ws._ws.send = (data) => {
-      assert.strictEqual(data, '[]')
-      done()
-    }
-
-    ws._sendCalc([])
-  })
-
-  it('notifyUI: throws error if supplied invalid arguments', () => {
-    const ws = new WSv2()
-
-    assert.throws(() => ws.notifyUI())
-    assert.throws(() => ws.notifyUI(null))
-    assert.throws(() => ws.notifyUI(null, null))
-  })
-
-  it('notifyUI: throws error if socket closed or not authenticated', () => {
-    const ws = new WSv2()
-    const n = { type: 'info', message: 'test' }
-
-    assert.throws(() => ws.notifyUI(n))
-    ws._isOpen = true
-    assert.throws(() => ws.notifyUI(n))
-    ws._isAuthenticated = true
-    ws.send = () => {}
-    assert.doesNotThrow(() => ws.notifyUI(n))
-  })
-
-  it('notifyUI: sends the correct UCM broadcast notification', (done) => {
-    const ws = new WSv2()
-    ws._isOpen = true
-    ws._isAuthenticated = true
-    ws.send = (msg = []) => {
-      assert.deepStrictEqual(msg[0], 0)
-      assert.deepStrictEqual(msg[1], 'n')
-      assert.deepStrictEqual(msg[2], null)
-
-      const data = msg[3]
-
-      assert(_isObject(data))
-      assert.deepStrictEqual(data.type, 'ucm-notify-ui')
-      assert(_isObject(data.info))
-      assert.deepStrictEqual(data.info.type, 'success')
-      assert.deepStrictEqual(data.info.message, '42')
-      done()
-    }
-
-    ws.notifyUI({ type: 'success', message: '42' })
-  })
-})
-
-describe('WSv2 lifetime', () => {
-  it('starts unopened & unauthenticated', () => {
-    const ws = createTestWSv2Instance()
-
-    assert.strictEqual(ws.isOpen(), false)
-    assert.strictEqual(ws.isAuthenticated(), false)
-  })
-
-  it('open: fails to open twice', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    try {
-      await ws.open()
-      assert(false)
-    } catch (e) {
-      wss.close()
-    }
-  })
-
-  it('open: updates open flag', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    assert.strictEqual(ws.isOpen(), true)
-    wss.close()
-  })
-
-  it('open: sends flags value', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-    let flagsSent = false
-
-    ws.enableSequencing()
-    ws.sendEnabledFlags = () => {
-      assert.strictEqual(ws._enabledFlags, WSv2.flags.SEQ_ALL)
-      flagsSent = true
-      wss.close()
-    }
-
-    await ws.open()
-
-    assert(flagsSent)
-  })
-
-  it('close: doesn\'t close if not open', async () => {
-    const ws = createTestWSv2Instance()
-
-    try {
-      await ws.close()
-      assert(false)
-    } catch (e) {}
-  })
-
-  it('close: fails to close twice', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    return new Promise((resolve, reject) => {
-      ws.on('close', async () => {
-        try {
-          await ws.close()
-          reject(new Error('closed twice'))
-        } catch (e) {
-          wss.close()
+          assert.strictEqual(packet.flags, WSv2.flags.CHECKSUM)
           resolve()
         }
+
+        ws.sendEnabledFlags()
       })
-
-      return ws.close()
-    })
-  })
-
-  it('close: clears connection state', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-    ws._onWSClose = () => {} // disable fallback reset
-
-    await ws.open()
-
-    assert(ws._ws !== null)
-    assert(ws._isOpen)
-
-    await ws.close()
-
-    assert(ws._ws == null)
-    assert(!ws._isOpen)
-
-    wss.close()
-  })
-
-  it('auth: fails to auth twice', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-    await ws.auth()
-
-    try {
-      await ws.auth()
-      assert(false)
-    } catch (e) {
-      wss.close()
-    }
-  })
-
-  it('auth: updates auth flag', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-    await ws.auth()
-
-    assert(ws.isAuthenticated())
-    wss.close()
-  })
-
-  it('auth: forwards calc param', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-    let sentCalc = false
-
-    await ws.open()
-
-    const send = ws.send
-    ws.send = (data) => {
-      assert.strictEqual(data.calc, 42)
-      sentCalc = true
-
-      ws.send = send
-      ws.send(data)
-    }
-
-    await ws.auth(42)
-
-    assert(sentCalc)
-    wss.close()
-  })
-
-  it('auth: forwards dms param', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-    let sentDMS = false
-
-    await ws.open()
-
-    const send = ws.send
-    ws.send = (data) => {
-      assert.strictEqual(data.dms, 42)
-      sentDMS = true
-
-      ws.send = send
-      ws.send(data)
-    }
-
-    await ws.auth(0, 42)
-
-    assert(sentDMS)
-    wss.close()
-  })
-
-  it('reconnect: connects if not already connected', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    let sawClose = false
-    let sawOpen = false
-
-    ws.on('close', () => { sawClose = true })
-    ws.on('open', () => { sawOpen = true })
-
-    await ws.reconnect()
-
-    assert(!sawClose)
-    assert(sawOpen)
-
-    wss.close()
-  })
-
-  it('reconnect: disconnects & connects back if currently connected', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    let sawClose = false
-    let sawOpen = false
-
-    ws.on('close', () => { sawClose = true })
-    ws.on('open', () => { sawOpen = true })
-
-    await ws.reconnect()
-
-    assert(sawClose)
-    assert(sawOpen)
-    assert(ws.isOpen())
-
-    wss.close()
-  })
-
-  it('reconnect: automatically auths on open if previously authenticated', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    let closed = false
-    let opened = false
-    let authenticated = false
-
-    ws.on('error', (error) => {
-      throw error
     })
 
-    await ws.open()
-    await ws.auth()
+    it('enableFlag: saves enabled flag status', () => {
+      ws = createTestWSv2Instance()
 
-    ws.once('close', () => { closed = true })
-    ws.once('open', () => { opened = true })
-    ws.once('auth', () => { authenticated = true })
+      assert(!ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
+      assert(!ws.isFlagEnabled(WSv2.flags.CHECKSUM))
 
-    await ws.reconnect()
+      ws.enableFlag(WSv2.flags.SEQ_ALL)
 
-    assert(closed)
-    assert(opened)
-    assert(authenticated)
-    wss.close()
-  })
-})
+      assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
+      assert(!ws.isFlagEnabled(WSv2.flags.CHECKSUM))
 
-describe('WSv2 constructor', () => {
-  it('defaults to production WS url', () => {
-    const ws = new WSv2()
-    assert.notStrictEqual(ws._url.indexOf('api.bitfinex.com'), -1)
-  })
+      ws.enableFlag(WSv2.flags.CHECKSUM)
 
-  it('defaults to no transform', () => {
-    const ws = createTestWSv2Instance()
-    const transWS = createTestWSv2Instance({ transform: true })
-    assert.strictEqual(ws._transform, false)
-    assert.strictEqual(transWS._transform, true)
-  })
-})
-
-describe('WSv2 auto reconnect', () => {
-  it('reconnects on close if autoReconnect is enabled', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance({
-      autoReconnect: true
+      assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
+      assert(ws.isFlagEnabled(WSv2.flags.CHECKSUM))
     })
 
-    await ws.open()
-    await ws.auth()
+    it('enableFlag: sends conf packet if open', async () => {
+      ws = createTestWSv2Instance()
+      wss = new MockWSv2Server()
 
-    return new Promise((resolve) => {
-      ws.reconnectAfterClose = new Promise(() => resolve())
-      wss.close() // trigger reconnect
+      await ws.open()
+
+      return new Promise((resolve) => {
+        ws.send = (packet) => {
+          assert(_isObject(packet))
+          assert.strictEqual(packet.event, 'conf')
+          resolve()
+        }
+
+        ws.enableFlag(WSv2.flags.SEQ_ALL)
+      })
     })
-  })
 
-  it('respects reconnectDelay', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance({
-      autoReconnect: true,
-      reconnectDelay: 75
+    it('_registerListener: correctly adds listener to internal map with cbGID', () => {
+      ws = createTestWSv2Instance()
+      ws._registerListener('trade', { 2: 'tBTCUSD' }, Map, 42, () => {})
+
+      const { _listeners } = ws
+
+      assert.strictEqual(Object.keys(_listeners).length, 1)
+      assert.strictEqual(+Object.keys(_listeners)[0], 42)
+      assert.strictEqual(typeof _listeners[42], 'object')
+
+      const listenerSet = _listeners[42]
+
+      assert.strictEqual(Object.keys(listenerSet).length, 1)
+      assert.strictEqual(Object.keys(listenerSet)[0], 'trade')
+      assert.strictEqual(listenerSet.trade.constructor.name, 'Array')
+      assert.strictEqual(listenerSet.trade.length, 1)
+
+      const listener = listenerSet.trade[0]
+
+      assert.strictEqual(listener.modelClass, Map)
+      assert.deepStrictEqual(listener.filter, { 2: 'tBTCUSD' })
+      assert.strictEqual(typeof listener.cb, 'function')
     })
 
-    await ws.open()
-    await ws.auth()
+    it('enableSequencing: sends the correct conf flag', async () => {
+      ws = createTestWSv2Instance()
+      wss = new MockWSv2Server()
+      let packetSent = false
 
-    return new Promise((resolve) => {
-      const now = Date.now()
+      await ws.open()
 
-      ws.reconnectAfterClose = () => {
-        assert((Date.now() - now) >= 70)
-        return new Promise(() => resolve())
+      ws.send = (packet) => {
+        assert.strictEqual(packet.event, 'conf')
+        assert.strictEqual(packet.flags, 65536)
+        packetSent = true
       }
 
-      wss.close() // trigger reconnect
+      ws.enableSequencing()
+
+      assert(packetSent)
+    })
+
+    it('getCandles: returns empty array if no candle set is available', () => {
+      ws = createTestWSv2Instance()
+      assert.deepStrictEqual(ws.getCandles('i.dont.exist'), [])
+    })
+
+    it('_sendCalc: stringifes payload & passes it to the ws client', (done) => {
+      ws = createTestWSv2Instance()
+
+      ws._ws = {}
+      ws._ws.send = (data) => {
+        assert.strictEqual(data, '[]')
+        done()
+      }
+
+      ws._sendCalc([])
+    })
+
+    it('notifyUI: throws error if supplied invalid arguments', () => {
+      ws = createTestWSv2Instance()
+
+      assert.throws(() => ws.notifyUI())
+      assert.throws(() => ws.notifyUI(null))
+      assert.throws(() => ws.notifyUI(null, null))
+    })
+
+    it('notifyUI: throws error if socket closed or not authenticated', () => {
+      ws = createTestWSv2Instance()
+      const n = { type: 'info', message: 'test' }
+
+      assert.throws(() => ws.notifyUI(n))
+      ws._isOpen = true
+      assert.throws(() => ws.notifyUI(n))
+      ws._isAuthenticated = true
+      ws.send = () => {}
+      assert.doesNotThrow(() => ws.notifyUI(n))
+    })
+
+    it('notifyUI: sends the correct UCM broadcast notification', (done) => {
+      ws = createTestWSv2Instance()
+      ws._isOpen = true
+      ws._isAuthenticated = true
+      ws.send = (msg = []) => {
+        assert.deepStrictEqual(msg[0], 0)
+        assert.deepStrictEqual(msg[1], 'n')
+        assert.deepStrictEqual(msg[2], null)
+
+        const data = msg[3]
+
+        assert(_isObject(data))
+        assert.deepStrictEqual(data.type, 'ucm-notify-ui')
+        assert(_isObject(data.info))
+        assert.deepStrictEqual(data.info.type, 'success')
+        assert.deepStrictEqual(data.info.message, '42')
+        done()
+      }
+
+      ws.notifyUI({ type: 'success', message: '42' })
     })
   })
 
-  it('does not auto-reconnect if explicity closed', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance({
-      autoReconnect: true
+  describe('lifetime', () => {
+    it('starts unopened & unauthenticated', () => {
+      ws = createTestWSv2Instance()
+
+      assert.strictEqual(ws.isOpen(), false)
+      assert.strictEqual(ws.isAuthenticated(), false)
     })
 
-    await ws.open()
-    await ws.auth()
+    it('open: fails to open twice', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
 
-    ws.reconnect = () => assert(false)
-    ws.close()
+      await ws.open()
 
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        wss.close()
-        resolve()
-      }, 50)
-    })
-  })
-})
-
-describe('WSv2 seq audit', () => {
-  it('automatically enables sequencing if seqAudit is true in constructor', () => {
-    const ws = createTestWSv2Instance({
-      seqAudit: true
+      try {
+        await ws.open()
+        assert(false)
+      } catch (e) {}
     })
 
-    assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
-  })
+    it('open: updates open flag', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
 
-  it('emits error on invalid seq number', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance({
-      seqAudit: true
+      await ws.open()
+
+      assert.strictEqual(ws.isOpen(), true)
     })
 
-    let errorsSeen = 0
+    it('open: sends flags value', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+      let flagsSent = false
 
-    await ws.open()
-    await ws.auth()
+      ws.enableSequencing()
+      ws.sendEnabledFlags = () => {
+        assert.strictEqual(ws._enabledFlags, WSv2.flags.SEQ_ALL)
+        flagsSent = true
+      }
 
-    ws.on('error', (err) => {
-      if (err.message.indexOf('seq #') !== -1) errorsSeen++
+      await ws.open()
 
-      return null
+      assert(flagsSent)
     })
 
-    ws._channelMap[42] = { channel: 'trades', chanId: 42 }
+    it('close: doesn\'t close if not open', async () => {
+      ws = createTestWSv2Instance()
 
-    ws._onWSMessage(JSON.stringify([0, 'tu', [], 0, 0]))
-    ws._onWSMessage(JSON.stringify([0, 'te', [], 1, 0]))
-    ws._onWSMessage(JSON.stringify([0, 'wu', [], 2, 1]))
-    ws._onWSMessage(JSON.stringify([0, 'tu', [], 3, 2])) //
-    ws._onWSMessage(JSON.stringify([0, 'tu', [], 4, 4])) // error
-    ws._onWSMessage(JSON.stringify([0, 'tu', [], 5, 5]))
-    ws._onWSMessage(JSON.stringify([0, 'tu', [], 6, 6]))
-    ws._onWSMessage(JSON.stringify([42, [], 7]))
-    ws._onWSMessage(JSON.stringify([42, [], 8]))
-    ws._onWSMessage(JSON.stringify([42, [], 9])) //
-    ws._onWSMessage(JSON.stringify([42, [], 13])) // error
-    ws._onWSMessage(JSON.stringify([42, [], 14]))
-    ws._onWSMessage(JSON.stringify([42, [], 15]))
-
-    assert.strictEqual(errorsSeen, 6)
-    wss.close()
-  })
-})
-
-describe('WSv2 ws event handlers', () => {
-  it('_onWSOpen: updates open flag', () => {
-    const ws = new WSv2()
-    assert(!ws.isOpen())
-    ws._onWSOpen()
-    assert(ws.isOpen())
-  })
-
-  it('_onWSClose: updates open flag', () => {
-    const ws = new WSv2()
-    ws._onWSOpen()
-    assert(ws.isOpen())
-    ws._onWSClose()
-    assert(!ws.isOpen())
-  })
-
-  it('_onWSError: emits error', (done) => {
-    const ws = new WSv2()
-    ws.on('error', () => done())
-    ws._onWSError(new Error())
-  })
-
-  it('_onWSMessage: emits error on invalid packet', (done) => {
-    const ws = new WSv2()
-    ws.on('error', () => done())
-    ws._onWSMessage('I can\'t believe it\'s not JSON!')
-  })
-
-  it('_onWSMessage: emits message', (done) => {
-    const ws = new WSv2()
-    const msg = [1]
-    const flags = 'flags'
-
-    ws.on('message', (m, f) => {
-      assert.deepStrictEqual(m, msg)
-      assert.strictEqual(flags, 'flags')
-      done()
+      try {
+        await ws.close()
+        assert(false)
+      } catch (e) {}
     })
 
-    ws._onWSMessage(JSON.stringify(msg), flags)
+    it('close: fails to close twice', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      return new Promise((resolve, reject) => {
+        ws.on('close', async () => {
+          try {
+            await ws.close()
+            assert(false)
+          } catch (e) {
+            resolve()
+          }
+        })
+
+        return ws.close()
+      })
+    })
+
+    it('close: clears connection state', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+      ws._onWSClose = () => {} // disable fallback reset
+
+      await ws.open()
+
+      assert(ws._ws !== null)
+      assert(ws._isOpen)
+
+      await ws.close()
+
+      assert(ws._ws == null)
+      assert(!ws._isOpen)
+    })
+
+    it('auth: fails to auth twice', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+      await ws.auth()
+
+      try {
+        await ws.auth()
+        assert(false)
+      } catch (e) {}
+    })
+
+    it('auth: updates auth flag', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+      await ws.auth()
+
+      assert(ws.isAuthenticated())
+    })
+
+    it('auth: forwards calc param', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+      let sentCalc = false
+
+      await ws.open()
+
+      const send = ws.send
+      ws.send = (data) => {
+        assert.strictEqual(data.calc, 42)
+        sentCalc = true
+
+        ws.send = send
+        ws.send(data)
+      }
+
+      await ws.auth(42)
+
+      assert(sentCalc)
+    })
+
+    it('auth: forwards dms param', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+      let sentDMS = false
+
+      await ws.open()
+
+      const send = ws.send
+      ws.send = (data) => {
+        assert.strictEqual(data.dms, 42)
+        sentDMS = true
+
+        ws.send = send
+        ws.send(data)
+      }
+
+      await ws.auth(0, 42)
+
+      assert(sentDMS)
+    })
+
+    it('reconnect: connects if not already connected', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      let sawClose = false
+      let sawOpen = false
+
+      ws.on('close', () => { sawClose = true })
+      ws.on('open', () => { sawOpen = true })
+
+      await ws.reconnect()
+
+      assert(!sawClose)
+      assert(sawOpen)
+    })
+
+    it('reconnect: disconnects & connects back if currently connected', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      let sawClose = false
+      let sawOpen = false
+
+      ws.on('close', () => { sawClose = true })
+      ws.on('open', () => { sawOpen = true })
+
+      await ws.reconnect()
+
+      assert(sawClose)
+      assert(sawOpen)
+      assert(ws.isOpen())
+    })
+
+    it('reconnect: automatically auths on open if previously authenticated', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      let closed = false
+      let opened = false
+      let authenticated = false
+
+      ws.on('error', (error) => {
+        throw error
+      })
+
+      await ws.open()
+      await ws.auth()
+
+      ws.once('close', () => { closed = true })
+      ws.once('open', () => { opened = true })
+      ws.once('auth', () => { authenticated = true })
+
+      await ws.reconnect()
+
+      assert(closed)
+      assert(opened)
+      assert(authenticated)
+    })
   })
 
-  it('_onWSNotification: triggers event callbacks for new orders', (done) => {
-    const ws = new WSv2()
-    const kNew = 'order-new-42'
+  describe('constructor', () => {
+    it('defaults to production WS url', () => {
+      ws = createTestWSv2Instance({ url: undefined })
+      assert.notStrictEqual(ws._url.indexOf('api.bitfinex.com'), -1)
+    })
 
-    ws._eventCallbacks.push(kNew, (err, order) => {
-      assert(!err)
-      assert(order)
-      assert.deepStrictEqual(order, [0, 0, 42])
+    it('defaults to no transform', () => {
+      ws = createTestWSv2Instance()
+      const transWS = createTestWSv2Instance({ transform: true })
+      assert.strictEqual(ws._transform, false)
+      assert.strictEqual(transWS._transform, true)
+    })
+  })
+
+  describe('auto reconnect', () => {
+    it('reconnects on close if autoReconnect is enabled', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance({ autoReconnect: true })
+
+      await ws.open()
+      await ws.auth()
+
+      return new Promise((resolve) => {
+        ws.reconnectAfterClose = new Promise(() => resolve())
+        wss.close() // trigger reconnect
+      })
+    })
+
+    it('respects reconnectDelay', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance({
+        autoReconnect: true,
+        reconnectDelay: 75
+      })
+
+      await ws.open()
+      await ws.auth()
+
+      return new Promise((resolve) => {
+        const now = Date.now()
+
+        ws.reconnectAfterClose = () => {
+          assert((Date.now() - now) >= 70)
+          return new Promise(() => resolve())
+        }
+
+        wss.close() // trigger reconnect
+      })
+    })
+
+    it('does not auto-reconnect if explicity closed', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance({
+        autoReconnect: true
+      })
+
+      await ws.open()
+      await ws.auth()
+
+      ws.reconnect = () => assert(false)
+      ws.close()
+
+      await new Promise(resolve => { setTimeout(resolve, 50) })
+    })
+  })
+
+  describe('seq audit', () => {
+    it('automatically enables sequencing if seqAudit is true in constructor', () => {
+      ws = createTestWSv2Instance({ seqAudit: true })
+      assert(ws.isFlagEnabled(WSv2.flags.SEQ_ALL))
+    })
+
+    it('emits error on invalid seq number', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance({ seqAudit: true })
+
+      let errorsSeen = 0
+
+      await ws.open()
+      await ws.auth()
+
+      ws.on('error', (err) => {
+        if (err.message.indexOf('seq #') !== -1) errorsSeen++
+
+        return null
+      })
+
+      ws._channelMap[42] = { channel: 'trades', chanId: 42 }
+
+      ws._onWSMessage(JSON.stringify([0, 'tu', [], 0, 0]))
+      ws._onWSMessage(JSON.stringify([0, 'te', [], 1, 0]))
+      ws._onWSMessage(JSON.stringify([0, 'wu', [], 2, 1]))
+      ws._onWSMessage(JSON.stringify([0, 'tu', [], 3, 2])) //
+      ws._onWSMessage(JSON.stringify([0, 'tu', [], 4, 4])) // error
+      ws._onWSMessage(JSON.stringify([0, 'tu', [], 5, 5]))
+      ws._onWSMessage(JSON.stringify([0, 'tu', [], 6, 6]))
+      ws._onWSMessage(JSON.stringify([42, [], 7]))
+      ws._onWSMessage(JSON.stringify([42, [], 8]))
+      ws._onWSMessage(JSON.stringify([42, [], 9])) //
+      ws._onWSMessage(JSON.stringify([42, [], 13])) // error
+      ws._onWSMessage(JSON.stringify([42, [], 14]))
+      ws._onWSMessage(JSON.stringify([42, [], 15]))
+
+      assert.strictEqual(errorsSeen, 6)
+    })
+  })
+
+  describe('ws event handlers', () => {
+    it('_onWSOpen: updates open flag', () => {
+      ws = createTestWSv2Instance()
+      assert(!ws.isOpen())
+      ws._onWSOpen()
+      assert(ws.isOpen())
+    })
+
+    it('_onWSClose: updates open flag', () => {
+      ws = createTestWSv2Instance()
+      ws._onWSOpen()
+      assert(ws.isOpen())
+      ws._onWSClose()
+      assert(!ws.isOpen())
+    })
+
+    it('_onWSError: emits error', (done) => {
+      ws = createTestWSv2Instance()
+      ws.on('error', () => done())
+      ws._onWSError(new Error())
+    })
+
+    it('_onWSMessage: emits error on invalid packet', (done) => {
+      ws = createTestWSv2Instance()
+      ws.on('error', () => done())
+      ws._onWSMessage('I can\'t believe it\'s not JSON!')
+    })
+
+    it('_onWSMessage: emits message', () => {
+      ws = createTestWSv2Instance()
+      const msg = [1]
+      const flags = 'flags'
+      let messageSeen = false
+
+      ws.on('message', (m, f) => {
+        assert.deepStrictEqual(m, msg)
+        assert.strictEqual(flags, 'flags')
+        messageSeen = true
+      })
+
+      ws._onWSMessage(JSON.stringify(msg), flags)
+      assert(messageSeen)
+    })
+
+    it('_onWSNotification: triggers event callbacks for new orders', (done) => {
+      ws = createTestWSv2Instance()
+      const kNew = 'order-new-42'
 
       ws._eventCallbacks.push(kNew, (err, order) => {
-        assert(err)
+        assert(!err)
+        assert(order)
         assert.deepStrictEqual(order, [0, 0, 42])
-        done()
+
+        ws._eventCallbacks.push(kNew, (err, order) => {
+          assert(err)
+          assert.deepStrictEqual(order, [0, 0, 42])
+          done()
+        })
+
+        ws._onWSNotification([0, 'on-req', null, null, [0, 0, 42], 0, 'ERROR'])
       })
 
-      ws._onWSNotification([0, 'on-req', null, null, [0, 0, 42], 0, 'ERROR'])
+      ws._onWSNotification([0, 'on-req', null, null, [0, 0, 42], 0, 'SUCCESS'])
     })
 
-    ws._onWSNotification([0, 'on-req', null, null, [0, 0, 42], 0, 'SUCCESS'])
-  })
-
-  it('_onWSNotification: triggers event callbacks for cancelled orders', (done) => {
-    const ws = new WSv2()
-    const kCancel = 'order-cancel-42'
-
-    ws._eventCallbacks.push(kCancel, (err, order) => {
-      assert(!err)
-      assert(order)
-      assert.deepStrictEqual(order, [42])
+    it('_onWSNotification: triggers event callbacks for cancelled orders', (done) => {
+      ws = createTestWSv2Instance()
+      const kCancel = 'order-cancel-42'
 
       ws._eventCallbacks.push(kCancel, (err, order) => {
-        assert(err)
+        assert(!err)
+        assert(order)
         assert.deepStrictEqual(order, [42])
+
+        ws._eventCallbacks.push(kCancel, (err, order) => {
+          assert(err)
+          assert.deepStrictEqual(order, [42])
+          done()
+        })
+
+        ws._onWSNotification([0, 'oc-req', null, null, [42], 0, 'ERROR'])
+      })
+
+      ws._onWSNotification([0, 'oc-req', null, null, [42], 0, 'SUCCESS'])
+    })
+  })
+
+  describe('WSv2 channel msg handling', () => {
+    it('_handleChannelMessage: emits message', () => {
+      ws = createTestWSv2Instance()
+
+      const packet = [42, 'tu', []]
+      let packetSeen = false
+
+      ws._channelMap = {
+        42: { channel: 'meaning' }
+      }
+
+      ws.on('meaning', (msg) => {
+        assert.deepStrictEqual(msg, packet)
+        packetSeen = true
+      })
+
+      ws._handleChannelMessage(packet)
+      assert(packetSeen)
+    })
+
+    it('_handleChannelMessage: calls all registered listeners (nofilter)', (done) => {
+      ws = createTestWSv2Instance()
+      ws._channelMap = { 0: { channel: 'auth' } }
+      let called = 0
+      ws.onWalletUpdate({}, () => {
+        if (++called === 2) done()
+      })
+
+      ws.onWalletUpdate({}, () => {
+        if (++called === 2) done()
+      })
+
+      ws._handleChannelMessage([0, 'wu', []])
+    })
+
+    const doFilterTest = (transform, done) => {
+      ws = new WSv2({ transform })
+      ws._channelMap = { 0: { channel: 'auth' } }
+      let calls = 0
+      let btcListenerCalled = false
+
+      ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
+        assert(!btcListenerCalled)
+        btcListenerCalled = true
+
+        if (++calls === 7) done()
+      })
+
+      ws.onAccountTradeEntry({}, () => {
+        if (++calls === 7) done()
+      })
+
+      ws.onAccountTradeEntry({}, () => {
+        if (++calls === 7) done()
+      })
+
+      ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
+      ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
+      ws._handleChannelMessage([0, 'te', [123, 'tBTCUSD']])
+    }
+
+    it('_handleChannelMessage: filters messages if listeners require it (transform)', (done) => {
+      doFilterTest(true, done)
+    })
+
+    it('_handleChannelMessage: filters messages if listeners require it (no transform)', (done) => {
+      doFilterTest(false, done)
+    })
+
+    it('_handleChannelMessage: transforms payloads if enabled', (done) => {
+      let calls = 0
+
+      const wsTransform = new WSv2({ transform: true })
+      const wsNoTransform = new WSv2({ transform: false })
+      wsTransform._channelMap = { 0: { channel: 'auth' } }
+      wsNoTransform._channelMap = { 0: { channel: 'auth' } }
+
+      const tradeData = [
+        0, 'tBTCUSD', Date.now(), 0, 0.1, 1, 'type', 1, false, 0.001, 'USD'
+      ]
+
+      wsNoTransform.onAccountTradeUpdate({}, (trade) => {
+        assert.strictEqual(trade.constructor.name, 'Array')
+        assert.deepStrictEqual(trade, tradeData)
+
+        if (calls++ === 1) done()
+      })
+
+      wsTransform.onAccountTradeUpdate({}, (trade) => {
+        assert.strictEqual(trade.constructor.name, 'Trade')
+        assert.strictEqual(trade.id, tradeData[0])
+        assert.strictEqual(trade.symbol, tradeData[1])
+        assert.strictEqual(trade.mtsCreate, tradeData[2])
+        assert.strictEqual(trade.orderID, tradeData[3])
+        assert.strictEqual(trade.execAmount, tradeData[4])
+        assert.strictEqual(trade.execPrice, tradeData[5])
+        assert.strictEqual(trade.orderType, tradeData[6])
+        assert.strictEqual(trade.orderPrice, tradeData[7])
+        assert.strictEqual(trade.maker, tradeData[8])
+        assert.strictEqual(trade.fee, tradeData[9])
+        assert.strictEqual(trade.feeCurrency, tradeData[10])
+
+        if (calls++ === 1) done()
+      })
+
+      wsTransform._handleChannelMessage([0, 'tu', tradeData])
+      wsNoTransform._handleChannelMessage([0, 'tu', tradeData])
+    })
+
+    it('onMessage: calls the listener with all messages (no filter)', (done) => {
+      ws = createTestWSv2Instance()
+      ws._channelMap = { 0: { channel: 'auth' } }
+
+      let calls = 0
+
+      ws.onMessage({}, (msg) => {
+        if (++calls === 2) done()
+      })
+
+      ws._handleChannelMessage([0, 'wu', []])
+      ws._handleChannelMessage([0, 'tu', []])
+    })
+
+    it('_payloadPassesFilter: correctly detects matching payloads', () => {
+      const filter = {
+        1: 'tBTCUSD'
+      }
+
+      const goodPayloads = [
+        [0, 'tBTCUSD', 42, ''],
+        [0, 'tBTCUSD', 3.14, '']
+      ]
+
+      const badPayloads = [
+        [0, 'tETHUSD', 42, ''],
+        [0, 'tETHUSD', 3.14, '']
+      ]
+
+      goodPayloads.forEach(p => assert(WSv2._payloadPassesFilter(p, filter)))
+      badPayloads.forEach(p => assert(!WSv2._payloadPassesFilter(p, filter)))
+    })
+
+    it('_notifyListenerGroup: notifies all matching listeners in the group', (done) => {
+      let calls = 0
+      const func = () => {
+        assert(calls < 3)
+        if (++calls === 2) done()
+      }
+
+      const lg = {
+        '': [{ cb: func }],
+        test: [{ cb: func }],
+        nope: [{ cb: func }]
+      }
+
+      WSv2._notifyListenerGroup(lg, [0, 'test', [0, 'tu']], false)
+    })
+
+    it('_notifyListenerGroup: doesn\'t fail on missing data if filtering', (done) => {
+      const lg = {
+        test: [{
+          filter: { 1: 'on' },
+          cb: () => {
+            done(new Error('filter should not have matched'))
+          }
+        }]
+      }
+
+      WSv2._notifyListenerGroup(lg, [0, 'test'], false)
+      done()
+    })
+
+    it('_propagateMessageToListeners: notifies all matching listeners', () => {
+      const ws = createTestWSv2Instance()
+      let seenMessage = false
+      ws._channelMap = { 0: { channel: 'auth' } }
+
+      ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
+        seenMessage = true
+      })
+
+      ws._propagateMessageToListeners([0, 'auth-te', [123, 'tBTCUSD']])
+      assert(seenMessage)
+    })
+
+    it('_notifyCatchAllListeners: passes data to all listeners on the empty \'\' event', () => {
+      let s = 0
+
+      const lg = {
+        '': [
+          { cb: d => { s += d } },
+          { cb: d => { s += (d * 2) } }
+        ]
+      }
+
+      WSv2._notifyCatchAllListeners(lg, 5)
+      assert.strictEqual(s, 15)
+    })
+
+    it('_handleOBMessage: maintains internal OB if management is enabled', () => {
+      ws = new WSv2({
+        manageOrderBooks: true,
+        transform: true
+      })
+
+      ws._channelMapA = {
+        42: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD'
+        }
+      }
+      ws._channelMapB = {
+        43: {
+          channel: 'orderbook',
+          symbol: 'fUSD'
+        }
+      }
+
+      let obMsg = [42, [
+        [100, 2, -4],
+        [200, 4, -8],
+        [300, 1, 3]
+      ]]
+
+      ws._handleOBMessage(obMsg, ws._channelMapA[42], JSON.stringify(obMsg))
+
+      obMsg = [43, [
+        [0.0008, 2, 5, 200],
+        [0.00045, 30, 4, -300],
+        [0.0004, 15, 3, -600]
+      ]]
+
+      ws._handleOBMessage(obMsg, ws._channelMapB[43], JSON.stringify(obMsg))
+
+      let obA = ws.getOB('tBTCUSD')
+      let obB = ws.getOB('fUSD')
+
+      assert(obA !== null)
+      assert(obB !== null)
+
+      assert.strictEqual(obA.bids.length, 1)
+      assert.strictEqual(obB.bids.length, 2)
+      assert.deepStrictEqual(obA.bids, [[300, 1, 3]])
+      assert.deepStrictEqual(obB.bids, [[0.00045, 30, 4, -300], [0.0004, 15, 3, -600]])
+      assert.strictEqual(obA.asks.length, 2)
+      assert.strictEqual(obB.asks.length, 1)
+      assert.deepStrictEqual(obA.getEntry(100), { price: 100, count: 2, amount: -4 })
+      assert.deepStrictEqual(obA.getEntry(200), { price: 200, count: 4, amount: -8 })
+      assert.deepStrictEqual(obB.getEntry(0.00045), { rate: 0.00045, count: 4, amount: -300, period: 30 })
+      assert.deepStrictEqual(obB.getEntry(0.0008), { rate: 0.0008, count: 5, amount: 200, period: 2 })
+
+      obMsg = [42, [300, 0, 1]]
+      ws._handleOBMessage(obMsg, ws._channelMapA[42], JSON.stringify(obMsg))
+      obA = ws.getOB('tBTCUSD')
+      assert.strictEqual(obA.bids.length, 0)
+      obMsg = [43, [0.0008, 2, 0, 1]]
+      ws._handleOBMessage(obMsg, ws._channelMapB[43], JSON.stringify(obMsg))
+      obB = ws.getOB('fUSD')
+      assert.strictEqual(obB.asks.length, 0)
+    })
+
+    it('_handleOBMessage: emits error on internal OB update failure', (done) => {
+      const wsNoTransform = new WSv2({ manageOrderBooks: true })
+      const wsTransform = new WSv2({
+        manageOrderBooks: true,
+        transform: true
+      })
+
+      wsNoTransform._channelMap = {
+        42: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD'
+        }
+      }
+
+      wsTransform._channelMap = wsNoTransform._channelMap
+
+      let errorsSeen = 0
+
+      wsNoTransform.on('error', () => {
+        if (++errorsSeen === 2) done()
+      })
+
+      wsTransform.on('error', () => {
+        if (++errorsSeen === 2) done()
+      })
+
+      const obMsg = [42, [100, 0, 1]]
+      wsTransform._handleOBMessage(obMsg, wsTransform._channelMap[42], JSON.stringify(obMsg))
+      wsNoTransform._handleOBMessage(obMsg, wsNoTransform._channelMap[42], JSON.stringify(obMsg))
+    })
+
+    it('_handleOBMessage: forwards managed ob to listeners', (done) => {
+      ws = new WSv2({ manageOrderBooks: true })
+      ws._channelMap = {
+        42: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD'
+        }
+      }
+
+      let seen = 0
+      ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
+        assert.deepStrictEqual(ob, [[100, 2, 3]])
+        if (++seen === 2) done()
+      })
+
+      ws.onOrderBook({}, (ob) => {
+        assert.deepStrictEqual(ob, [[100, 2, 3]])
+        if (++seen === 2) done()
+      })
+
+      const obMsg = [42, [[100, 2, 3]]]
+      ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
+    })
+
+    it('_handleOBMessage: filters by prec and len', (done) => {
+      ws = new WSv2({ manageOrderBooks: true })
+      ws._channelMap = {
+        40: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD',
+          prec: 'P0'
+        },
+
+        41: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD',
+          prec: 'P1'
+        },
+
+        42: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD',
+          prec: 'P2'
+        }
+      }
+
+      let seen = 0
+      ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P0' }, (ob) => {
+        assert(false)
+      })
+
+      ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P1' }, (ob) => {
+        assert(false)
+      })
+
+      ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P2' }, (ob) => {
+        if (++seen === 2) done()
+      })
+
+      const obMsg = [42, [[100, 2, 3]]]
+      ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
+      ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
+    })
+
+    it('_handleOBMessage: emits managed ob', (done) => {
+      ws = new WSv2({ manageOrderBooks: true })
+      ws._channelMap = {
+        42: {
+          channel: 'orderbook',
+          symbol: 'tBTCUSD'
+        }
+      }
+
+      ws.on('orderbook', (symbol, data) => {
+        assert.strictEqual(symbol, 'tBTCUSD')
+        assert.deepStrictEqual(data, [[100, 2, 3]])
         done()
       })
 
-      ws._onWSNotification([0, 'oc-req', null, null, [42], 0, 'ERROR'])
+      const obMsg = [42, [[100, 2, 3]]]
+      ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
     })
 
-    ws._onWSNotification([0, 'oc-req', null, null, [42], 0, 'SUCCESS'])
-  })
-})
-
-describe('WSv2 channel msg handling', () => {
-  it('_handleChannelMessage: emits message', (done) => {
-    const ws = new WSv2()
-    const packet = [42, 'tu', []]
-    ws._channelMap = {
-      42: { channel: 'meaning' }
-    }
-    ws.on('meaning', (msg) => {
-      assert.deepStrictEqual(msg, packet)
-      done()
-    })
-
-    ws._handleChannelMessage(packet)
-  })
-
-  it('_handleChannelMessage: calls all registered listeners (nofilter)', (done) => {
-    const ws = new WSv2()
-    ws._channelMap = { 0: { channel: 'auth' } }
-    let called = 0
-    ws.onWalletUpdate({}, () => {
-      if (++called === 2) done()
-    })
-
-    ws.onWalletUpdate({}, () => {
-      if (++called === 2) done()
-    })
-
-    ws._handleChannelMessage([0, 'wu', []])
-  })
-
-  const doFilterTest = (transform, done) => {
-    const ws = new WSv2({ transform })
-    ws._channelMap = { 0: { channel: 'auth' } }
-    let calls = 0
-    let btcListenerCalled = false
-
-    ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
-      assert(!btcListenerCalled)
-      btcListenerCalled = true
-
-      if (++calls === 7) done()
-    })
-
-    ws.onAccountTradeEntry({}, () => {
-      if (++calls === 7) done()
-    })
-
-    ws.onAccountTradeEntry({}, () => {
-      if (++calls === 7) done()
-    })
-
-    ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
-    ws._handleChannelMessage([0, 'te', [123, 'tETHUSD']])
-    ws._handleChannelMessage([0, 'te', [123, 'tBTCUSD']])
-  }
-
-  it('_handleChannelMessage: filters messages if listeners require it (transform)', (done) => {
-    doFilterTest(true, done)
-  })
-
-  it('_handleChannelMessage: filters messages if listeners require it (no transform)', (done) => {
-    doFilterTest(false, done)
-  })
-
-  it('_handleChannelMessage: transforms payloads if enabled', (done) => {
-    let calls = 0
-
-    const wsTransform = new WSv2({ transform: true })
-    const wsNoTransform = new WSv2({ transform: false })
-    wsTransform._channelMap = { 0: { channel: 'auth' } }
-    wsNoTransform._channelMap = { 0: { channel: 'auth' } }
-
-    const tradeData = [
-      0, 'tBTCUSD', Date.now(), 0, 0.1, 1, 'type', 1, false, 0.001, 'USD'
-    ]
-
-    wsNoTransform.onAccountTradeUpdate({}, (trade) => {
-      assert.strictEqual(trade.constructor.name, 'Array')
-      assert.deepStrictEqual(trade, tradeData)
-
-      if (calls++ === 1) done()
-    })
-
-    wsTransform.onAccountTradeUpdate({}, (trade) => {
-      assert.strictEqual(trade.constructor.name, 'Trade')
-      assert.strictEqual(trade.id, tradeData[0])
-      assert.strictEqual(trade.symbol, tradeData[1])
-      assert.strictEqual(trade.mtsCreate, tradeData[2])
-      assert.strictEqual(trade.orderID, tradeData[3])
-      assert.strictEqual(trade.execAmount, tradeData[4])
-      assert.strictEqual(trade.execPrice, tradeData[5])
-      assert.strictEqual(trade.orderType, tradeData[6])
-      assert.strictEqual(trade.orderPrice, tradeData[7])
-      assert.strictEqual(trade.maker, tradeData[8])
-      assert.strictEqual(trade.fee, tradeData[9])
-      assert.strictEqual(trade.feeCurrency, tradeData[10])
-
-      if (calls++ === 1) done()
-    })
-
-    wsTransform._handleChannelMessage([0, 'tu', tradeData])
-    wsNoTransform._handleChannelMessage([0, 'tu', tradeData])
-  })
-
-  it('onMessage: calls the listener with all messages (no filter)', (done) => {
-    const ws = new WSv2()
-    ws._channelMap = { 0: { channel: 'auth' } }
-
-    let calls = 0
-
-    ws.onMessage({}, (msg) => {
-      if (++calls === 2) done()
-    })
-
-    ws._handleChannelMessage([0, 'wu', []])
-    ws._handleChannelMessage([0, 'tu', []])
-  })
-
-  it('_payloadPassesFilter: correctly detects matching payloads', () => {
-    const filter = {
-      1: 'tBTCUSD'
-    }
-
-    const goodPayloads = [
-      [0, 'tBTCUSD', 42, ''],
-      [0, 'tBTCUSD', 3.14, '']
-    ]
-
-    const badPayloads = [
-      [0, 'tETHUSD', 42, ''],
-      [0, 'tETHUSD', 3.14, '']
-    ]
-
-    goodPayloads.forEach(p => assert(WSv2._payloadPassesFilter(p, filter)))
-    badPayloads.forEach(p => assert(!WSv2._payloadPassesFilter(p, filter)))
-  })
-
-  it('_notifyListenerGroup: notifies all matching listeners in the group', (done) => {
-    let calls = 0
-    const func = () => {
-      assert(calls < 3)
-      if (++calls === 2) done()
-    }
-
-    const lg = {
-      '': [{ cb: func }],
-      test: [{ cb: func }],
-      nope: [{ cb: func }]
-    }
-
-    WSv2._notifyListenerGroup(lg, [0, 'test', [0, 'tu']], false)
-  })
-
-  it('_notifyListenerGroup: doesn\'t fail on missing data if filtering', (done) => {
-    const lg = {
-      test: [{
-        filter: { 1: 'on' },
-        cb: () => {
-          done(new Error('filter should not have matched'))
+    it('_handleOBMessage: forwards transformed data if transform enabled', (done) => {
+      ws = new WSv2({ transform: true })
+      ws._channelMap = {
+        42: {
+          chanId: 42,
+          channel: 'orderbook',
+          symbol: 'tBTCUSD'
         }
-      }]
-    }
-
-    WSv2._notifyListenerGroup(lg, [0, 'test'], false)
-    done()
-  })
-
-  it('_propagateMessageToListeners: notifies all matching listeners', (done) => {
-    const ws = new WSv2()
-    ws._channelMap = { 0: { channel: 'auth' } }
-
-    ws.onAccountTradeEntry({ symbol: 'tBTCUSD' }, () => {
-      done()
-    })
-
-    ws._propagateMessageToListeners([0, 'auth-te', [123, 'tBTCUSD']])
-  })
-
-  it('_notifyCatchAllListeners: passes data to all listeners on the empty \'\' event', () => {
-    let s = 0
-
-    const lg = {
-      '': [
-        { cb: d => { s += d } },
-        { cb: d => { s += (d * 2) } }
-      ]
-    }
-
-    WSv2._notifyCatchAllListeners(lg, 5)
-    assert.strictEqual(s, 15)
-  })
-
-  it('_handleOBMessage: maintains internal OB if management is enabled', () => {
-    const ws = new WSv2({
-      manageOrderBooks: true,
-      transform: true
-    })
-
-    ws._channelMapA = {
-      42: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD'
       }
-    }
-    ws._channelMapB = {
-      43: {
-        channel: 'orderbook',
-        symbol: 'fUSD'
-      }
-    }
 
-    let obMsg = [42, [
-      [100, 2, -4],
-      [200, 4, -8],
-      [300, 1, 3]
-    ]]
-    ws._handleOBMessage(obMsg, ws._channelMapA[42], JSON.stringify(obMsg))
-    obMsg = [43, [
-      [0.0008, 2, 5, 200],
-      [0.00045, 30, 4, -300],
-      [0.0004, 15, 3, -600]
-    ]]
-    ws._handleOBMessage(obMsg, ws._channelMapB[43], JSON.stringify(obMsg))
-
-    let obA = ws.getOB('tBTCUSD')
-    let obB = ws.getOB('fUSD')
-
-    assert(obA !== null)
-    assert(obB !== null)
-
-    assert.strictEqual(obA.bids.length, 1)
-    assert.strictEqual(obB.bids.length, 2)
-    assert.deepStrictEqual(obA.bids, [[300, 1, 3]])
-    assert.deepStrictEqual(obB.bids, [[0.00045, 30, 4, -300], [0.0004, 15, 3, -600]])
-    assert.strictEqual(obA.asks.length, 2)
-    assert.strictEqual(obB.asks.length, 1)
-    assert.deepStrictEqual(obA.getEntry(100), { price: 100, count: 2, amount: -4 })
-    assert.deepStrictEqual(obA.getEntry(200), { price: 200, count: 4, amount: -8 })
-    assert.deepStrictEqual(obB.getEntry(0.00045), { rate: 0.00045, count: 4, amount: -300, period: 30 })
-    assert.deepStrictEqual(obB.getEntry(0.0008), { rate: 0.0008, count: 5, amount: 200, period: 2 })
-
-    obMsg = [42, [300, 0, 1]]
-    ws._handleOBMessage(obMsg, ws._channelMapA[42], JSON.stringify(obMsg))
-    obA = ws.getOB('tBTCUSD')
-    assert.strictEqual(obA.bids.length, 0)
-    obMsg = [43, [0.0008, 2, 0, 1]]
-    ws._handleOBMessage(obMsg, ws._channelMapB[43], JSON.stringify(obMsg))
-    obB = ws.getOB('fUSD')
-    assert.strictEqual(obB.asks.length, 0)
-  })
-
-  it('_handleOBMessage: emits error on internal OB update failure', (done) => {
-    const wsNoTransform = new WSv2({ manageOrderBooks: true })
-    const wsTransform = new WSv2({
-      manageOrderBooks: true,
-      transform: true
-    })
-
-    wsNoTransform._channelMap = {
-      42: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD'
-      }
-    }
-
-    wsTransform._channelMap = wsNoTransform._channelMap
-
-    let errorsSeen = 0
-
-    wsNoTransform.on('error', () => {
-      if (++errorsSeen === 2) done()
-    })
-
-    wsTransform.on('error', () => {
-      if (++errorsSeen === 2) done()
-    })
-
-    const obMsg = [42, [100, 0, 1]]
-    wsTransform._handleOBMessage(obMsg, wsTransform._channelMap[42], JSON.stringify(obMsg))
-    wsNoTransform._handleOBMessage(obMsg, wsNoTransform._channelMap[42], JSON.stringify(obMsg))
-  })
-
-  it('_handleOBMessage: forwards managed ob to listeners', (done) => {
-    const ws = new WSv2({ manageOrderBooks: true })
-    ws._channelMap = {
-      42: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD'
-      }
-    }
-
-    let seen = 0
-    ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
-      assert.deepStrictEqual(ob, [[100, 2, 3]])
-      if (++seen === 2) done()
-    })
-
-    ws.onOrderBook({}, (ob) => {
-      assert.deepStrictEqual(ob, [[100, 2, 3]])
-      if (++seen === 2) done()
-    })
-
-    const obMsg = [42, [[100, 2, 3]]]
-    ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
-  })
-
-  it('_handleOBMessage: filters by prec and len', (done) => {
-    const ws = new WSv2({ manageOrderBooks: true })
-    ws._channelMap = {
-      40: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD',
-        prec: 'P0'
-      },
-
-      41: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD',
-        prec: 'P1'
-      },
-
-      42: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD',
-        prec: 'P2'
-      }
-    }
-
-    let seen = 0
-    ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P0' }, (ob) => {
-      assert(false)
-    })
-
-    ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P1' }, (ob) => {
-      assert(false)
-    })
-
-    ws.onOrderBook({ symbol: 'tBTCUSD', prec: 'P2' }, (ob) => {
-      if (++seen === 2) done()
-    })
-
-    const obMsg = [42, [[100, 2, 3]]]
-    ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
-    ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
-  })
-
-  it('_handleOBMessage: emits managed ob', (done) => {
-    const ws = new WSv2({ manageOrderBooks: true })
-    ws._channelMap = {
-      42: {
-        channel: 'orderbook',
-        symbol: 'tBTCUSD'
-      }
-    }
-
-    ws.on('orderbook', (symbol, data) => {
-      assert.strictEqual(symbol, 'tBTCUSD')
-      assert.deepStrictEqual(data, [[100, 2, 3]])
-      done()
-    })
-
-    const obMsg = [42, [[100, 2, 3]]]
-    ws._handleOBMessage(obMsg, ws._channelMap[42], JSON.stringify(obMsg))
-  })
-
-  it('_handleOBMessage: forwards transformed data if transform enabled', (done) => {
-    const ws = new WSv2({ transform: true })
-    ws._channelMap = {
-      42: {
-        chanId: 42,
-        channel: 'orderbook',
-        symbol: 'tBTCUSD'
-      }
-    }
-
-    ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
-      assert(ob.asks)
-      assert(ob.bids)
-      assert.strictEqual(ob.asks.length, 0)
-      assert.deepStrictEqual(ob.bids, [[100, 2, 3]])
-      done()
-    })
-
-    const obMsg = [42, [[100, 2, 3]]]
-    ws._handleOBMessage(obMsg, ws._channelMap[42], obMsg)
-  })
-
-  it('_updateManagedOB: does nothing on rm non-existent entry', () => {
-    const ws = new WSv2()
-    ws._orderBooks.tBTCUSD = [
-      [100, 1, 1],
-      [200, 2, 1]
-    ]
-    ws._losslessOrderBooks.tBTCUSD = [
-      ['100', '1', '1'],
-      ['200', '2', '1']
-    ]
-
-    const err = ws._updateManagedOB('tBTCUSD', [150, 0, -1], false, JSON.stringify([1, [150, 0, -1]]))
-    assert.strictEqual(err, null)
-    assert.deepStrictEqual(ws._orderBooks.tBTCUSD, [
-      [100, 1, 1],
-      [200, 2, 1]
-    ])
-  })
-
-  it('_updateManagedOB: correctly maintains transformed OBs', () => {
-    const ws = new WSv2({ transform: true })
-    ws._orderBooks.tBTCUSD = []
-    ws._losslessOrderBooks.tBTCUSD = []
-
-    // symbol, data, raw, rawMsg
-    assert(!ws._updateManagedOB('tBTCUSD', [100, 1, 1], false, JSON.stringify([1, [100, 1, 1]])))
-    assert(!ws._updateManagedOB('tBTCUSD', [200, 1, -1], false, JSON.stringify([1, [200, 1, -1]])))
-    assert(!ws._updateManagedOB('tBTCUSD', [200, 0, -1], false, JSON.stringify([1, [200, 0, -1]])))
-
-    const ob = ws.getOB('tBTCUSD')
-
-    assert.strictEqual(ob.bids.length, 1)
-    assert.strictEqual(ob.asks.length, 0)
-    assert.deepStrictEqual(ob.bids, [[100, 1, 1]])
-  })
-
-  it('_updateManagedOB: correctly maintains non-transformed OBs', () => {
-    const ws = new WSv2()
-    ws._orderBooks.tBTCUSD = []
-    ws._losslessOrderBooks.tBTCUSD = []
-
-    assert(!ws._updateManagedOB('tBTCUSD', [100, 1, 1], false, JSON.stringify([1, [100, 1, 1]])))
-    assert(!ws._updateManagedOB('tBTCUSD', [200, 1, -1], false, JSON.stringify([1, [200, 1, -1]])))
-    assert(!ws._updateManagedOB('tBTCUSD', [200, 0, -1], false, JSON.stringify([1, [200, 0, -1]])))
-
-    const ob = ws._orderBooks.tBTCUSD
-
-    assert.strictEqual(ob.length, 1)
-    assert.deepStrictEqual(ob, [[100, 1, 1]])
-  })
-
-  it('_handleCandleMessage: maintains internal candles if management is enabled', () => {
-    const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = {
-      64: {
-        channel: 'candles',
-        key: 'trade:1m:tBTCUSD'
-      }
-    }
-
-    ws._handleCandleMessage([64, [
-      [5, 100, 70, 150, 30, 1000],
-      [2, 200, 90, 150, 30, 1000],
-      [1, 130, 90, 150, 30, 1000],
-      [4, 104, 80, 150, 30, 1000]
-    ]], ws._channelMap[64])
-
-    const candles = ws._candles['trade:1m:tBTCUSD']
-
-    // maintains sort
-    assert.strictEqual(candles.length, 4)
-    assert.strictEqual(candles[0][0], 5)
-    assert.strictEqual(candles[1][0], 4)
-    assert.strictEqual(candles[2][0], 2)
-    assert.strictEqual(candles[3][0], 1)
-
-    // updates existing candle
-    ws._handleCandleMessage([
-      64,
-      [5, 200, 20, 220, 20, 2000]
-    ], ws._channelMap[64])
-
-    assert.deepStrictEqual(candles[0], [5, 200, 20, 220, 20, 2000])
-
-    // inserts new candle
-    ws._handleCandleMessage([
-      64,
-      [10, 300, 20, 450, 10, 4000]
-    ], ws._channelMap[64])
-
-    assert.deepStrictEqual(candles[0], [10, 300, 20, 450, 10, 4000])
-  })
-
-  it('_handleCandleMessage: emits error on internal candle update failure', (done) => {
-    const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = {
-      42: {
-        channel: 'candles',
-        key: 'trade:30m:tBTCUSD'
-      },
-
-      64: {
-        channel: 'candles',
-        key: 'trade:1m:tBTCUSD'
-      }
-    }
-
-    let errorsSeen = 0
-
-    ws.on('error', () => {
-      if (++errorsSeen === 1) done()
-    })
-
-    ws._handleCandleMessage([64, [
-      [5, 100, 70, 150, 30, 1000],
-      [2, 200, 90, 150, 30, 1000],
-      [1, 130, 90, 150, 30, 1000],
-      [4, 104, 80, 150, 30, 1000]
-    ]], ws._channelMap[64])
-
-    // update for unknown key
-    ws._handleCandleMessage([
-      42,
-      [5, 10, 70, 150, 30, 10]
-    ], ws._channelMap[42])
-  })
-
-  it('_handleCandleMessage: forwards managed candles to listeners', (done) => {
-    const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = {
-      42: {
-        chanId: 42,
-        channel: 'candles',
-        key: 'trade:1m:tBTCUSD'
-      }
-    }
-
-    let seen = 0
-    ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (data) => {
-      assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
-      if (++seen === 2) done()
-    })
-
-    ws.onCandle({}, (data) => {
-      assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
-      if (++seen === 2) done()
-    })
-
-    ws._handleCandleMessage([
-      42,
-      [[5, 10, 70, 150, 30, 10]]
-    ], ws._channelMap[42])
-  })
-
-  it('_handleCandleMessage: emits managed candles', (done) => {
-    const ws = new WSv2({ manageCandles: true })
-    ws._channelMap = {
-      42: {
-        channel: 'candles',
-        key: 'trade:1m:tBTCUSD'
-      }
-    }
-
-    ws.on('candle', (data, key) => {
-      assert.strictEqual(key, 'trade:1m:tBTCUSD')
-      assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
-      done()
-    })
-
-    ws._handleCandleMessage([
-      42,
-      [[5, 10, 70, 150, 30, 10]]
-    ], ws._channelMap[42])
-  })
-
-  it('_handleCandleMessage: forwards transformed data if transform enabled', (done) => {
-    const ws = new WSv2({ transform: true })
-    ws._channelMap = {
-      42: {
-        chanId: 42,
-        channel: 'candles',
-        key: 'trade:1m:tBTCUSD'
-      }
-    }
-
-    ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (candles) => {
-      assert.strictEqual(candles.length, 1)
-      assert.deepStrictEqual(candles[0], {
-        mts: 5,
-        open: 10,
-        close: 70,
-        high: 150,
-        low: 30,
-        volume: 10
+      ws.onOrderBook({ symbol: 'tBTCUSD' }, (ob) => {
+        assert(ob.asks)
+        assert(ob.bids)
+        assert.strictEqual(ob.asks.length, 0)
+        assert.deepStrictEqual(ob.bids, [[100, 2, 3]])
+        done()
       })
 
-      done()
+      const obMsg = [42, [[100, 2, 3]]]
+      ws._handleOBMessage(obMsg, ws._channelMap[42], obMsg)
     })
 
-    ws._handleCandleMessage([
-      42,
-      [[5, 10, 70, 150, 30, 10]]
-    ], ws._channelMap[42])
-  })
+    it('_updateManagedOB: does nothing on rm non-existent entry', () => {
+      ws = createTestWSv2Instance()
+      ws._orderBooks.tBTCUSD = [
+        [100, 1, 1],
+        [200, 2, 1]
+      ]
+      ws._losslessOrderBooks.tBTCUSD = [
+        ['100', '1', '1'],
+        ['200', '2', '1']
+      ]
 
-  it('_updateManagedCandles: returns an error on update for unknown key', () => {
-    const ws = new WSv2()
-    ws._candles['trade:1m:tBTCUSD'] = []
-
-    const err = ws._updateManagedCandles('trade:30m:tBTCUSD', [
-      1, 10, 70, 150, 30, 10
-    ])
-
-    assert(err)
-    assert(err instanceof Error)
-  })
-
-  it('_updateManagedCandles: correctly maintains transformed OBs', () => {
-    const ws = new WSv2({ transform: true })
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      [1, 10, 70, 150, 30, 10],
-      [2, 10, 70, 150, 30, 10]
-    ]))
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      2, 10, 70, 150, 30, 500
-    ]))
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      3, 100, 70, 150, 30, 10
-    ]))
-
-    const candles = ws._candles['trade:1m:tBTCUSD']
-
-    assert.strictEqual(candles.length, 3)
-    assert.deepStrictEqual(candles[0], [
-      3, 100, 70, 150, 30, 10
-    ])
-
-    assert.deepStrictEqual(candles[1], [
-      2, 10, 70, 150, 30, 500
-    ])
-
-    assert.deepStrictEqual(candles[2], [
-      1, 10, 70, 150, 30, 10
-    ])
-  })
-
-  it('_updateManagedCandles: correctly maintains non-transformed OBs', () => {
-    const ws = new WSv2()
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      [1, 10, 70, 150, 30, 10],
-      [2, 10, 70, 150, 30, 10]
-    ]))
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      2, 10, 70, 150, 30, 500
-    ]))
-
-    assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
-      3, 100, 70, 150, 30, 10
-    ]))
-
-    const candles = ws._candles['trade:1m:tBTCUSD']
-
-    assert.strictEqual(candles.length, 3)
-    assert.deepStrictEqual(candles[0], [
-      3, 100, 70, 150, 30, 10
-    ])
-
-    assert.deepStrictEqual(candles[1], [
-      2, 10, 70, 150, 30, 500
-    ])
-
-    assert.deepStrictEqual(candles[2], [
-      1, 10, 70, 150, 30, 10
-    ])
-  })
-})
-
-describe('WSv2 event msg handling', () => {
-  it('_handleErrorEvent: emits error', (done) => {
-    const ws = new WSv2()
-    ws.on('error', (err) => {
-      if (err === 42) done()
+      const err = ws._updateManagedOB('tBTCUSD', [150, 0, -1], false, JSON.stringify([1, [150, 0, -1]]))
+      assert.strictEqual(err, null)
+      assert.deepStrictEqual(ws._orderBooks.tBTCUSD, [
+        [100, 1, 1],
+        [200, 2, 1]
+      ])
     })
-    ws._handleErrorEvent(42)
-  })
 
-  it('_handleConfigEvent: emits error if config failed', (done) => {
-    const ws = new WSv2()
-    ws.on('error', (err) => {
-      if (err.message.indexOf('42') !== -1) done()
+    it('_updateManagedOB: correctly maintains transformed OBs', () => {
+      ws = new WSv2({ transform: true })
+      ws._orderBooks.tBTCUSD = []
+      ws._losslessOrderBooks.tBTCUSD = []
+
+      // symbol, data, raw, rawMsg
+      assert(!ws._updateManagedOB('tBTCUSD', [100, 1, 1], false, JSON.stringify([1, [100, 1, 1]])))
+      assert(!ws._updateManagedOB('tBTCUSD', [200, 1, -1], false, JSON.stringify([1, [200, 1, -1]])))
+      assert(!ws._updateManagedOB('tBTCUSD', [200, 0, -1], false, JSON.stringify([1, [200, 0, -1]])))
+
+      const ob = ws.getOB('tBTCUSD')
+
+      assert.strictEqual(ob.bids.length, 1)
+      assert.strictEqual(ob.asks.length, 0)
+      assert.deepStrictEqual(ob.bids, [[100, 1, 1]])
     })
-    ws._handleConfigEvent({ status: 'bad', flags: 42 })
-  })
 
-  it('_handleAuthEvent: emits an error on auth fail', (done) => {
-    const ws = new WSv2()
-    ws.on('error', () => {
-      done()
+    it('_updateManagedOB: correctly maintains non-transformed OBs', () => {
+      ws = createTestWSv2Instance()
+      ws._orderBooks.tBTCUSD = []
+      ws._losslessOrderBooks.tBTCUSD = []
+
+      assert(!ws._updateManagedOB('tBTCUSD', [100, 1, 1], false, JSON.stringify([1, [100, 1, 1]])))
+      assert(!ws._updateManagedOB('tBTCUSD', [200, 1, -1], false, JSON.stringify([1, [200, 1, -1]])))
+      assert(!ws._updateManagedOB('tBTCUSD', [200, 0, -1], false, JSON.stringify([1, [200, 0, -1]])))
+
+      const ob = ws._orderBooks.tBTCUSD
+
+      assert.strictEqual(ob.length, 1)
+      assert.deepStrictEqual(ob, [[100, 1, 1]])
     })
-    ws._handleAuthEvent({ status: 'FAIL' })
-  })
 
-  it('_handleAuthEvent: updates auth flag on auth success', () => {
-    const ws = new WSv2()
-    assert(!ws.isAuthenticated())
-    ws._handleAuthEvent({ status: 'OK' })
-    assert(ws.isAuthenticated())
-  })
-
-  it('_handleAuthEvent: adds auth channel to channel map', () => {
-    const ws = new WSv2()
-    assert(Object.keys(ws._channelMap).length === 0)
-    ws._handleAuthEvent({ chanId: 42, status: 'OK' })
-    assert(ws._channelMap[42])
-    assert.strictEqual(ws._channelMap[42].channel, 'auth')
-  })
-
-  it('_handleAuthEvent: emits auth message', (done) => {
-    const ws = new WSv2()
-    ws.once('auth', (msg) => {
-      assert.strictEqual(msg.chanId, 0)
-      assert.strictEqual(msg.status, 'OK')
-      done()
-    })
-    ws._handleAuthEvent({ chanId: 0, status: 'OK' })
-  })
-
-  it('_handleSubscribedEvent: adds channel to channel map', () => {
-    const ws = new WSv2()
-    assert(Object.keys(ws._channelMap).length === 0)
-    ws._handleSubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
-    assert(ws._channelMap[42])
-    assert.strictEqual(ws._channelMap[42].chanId, 42)
-    assert.strictEqual(ws._channelMap[42].channel, 'test')
-    assert.strictEqual(ws._channelMap[42].extra, 'stuff')
-  })
-
-  it('_handleUnsubscribedEvent: removes channel from channel map', () => {
-    const ws = new WSv2()
-    assert(Object.keys(ws._channelMap).length === 0)
-    ws._handleSubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
-    ws._handleUnsubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
-    assert(Object.keys(ws._channelMap).length === 0)
-  })
-
-  it('_handleInfoEvent: passes message to relevant listeners (raw access)', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    let n = 0
-
-    ws._infoListeners[42] = [
-      () => { n += 1 },
-      () => { n += 2 }
-    ]
-
-    ws._handleInfoEvent({ code: 42 })
-
-    assert.strictEqual(n, 3)
-    wss.close()
-  })
-
-  it('_handleInfoEvent: passes message to relevant listeners', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    let n = 0
-
-    ws.onInfoMessage(42, () => { n += 1 })
-    ws.onInfoMessage(42, () => { n += 2 })
-    ws._handleInfoEvent({ code: 42 })
-
-    assert.strictEqual(n, 3)
-    wss.close()
-  })
-
-  it('_handleInfoEvent: passes message to relevant named listeners', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    let n = 0
-
-    ws.onServerRestart(() => { n += 1 })
-    ws.onMaintenanceStart(() => { n += 10 })
-    ws.onMaintenanceEnd(() => { n += 100 })
-
-    ws._handleInfoEvent({ code: WSv2.info.SERVER_RESTART })
-    ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_START })
-    ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_END })
-
-    assert.strictEqual(n, 111)
-    wss.close()
-  })
-
-  it('_handleInfoEvent: closes & emits error if not on api v2', async () => {
-    const wss = new MockWSv2Server()
-    const ws = createTestWSv2Instance()
-
-    await ws.open()
-
-    return new Promise((resolve) => {
-      let seen = 0
-      const d = () => {
-        wss.close()
-        resolve()
+    it('_handleCandleMessage: maintains internal candles if management is enabled', () => {
+      ws = new WSv2({ manageCandles: true })
+      ws._channelMap = {
+        64: {
+          channel: 'candles',
+          key: 'trade:1m:tBTCUSD'
+        }
       }
 
-      ws.on('error', () => { if (++seen === 2) { d() } })
-      ws.on('close', () => { if (++seen === 2) { d() } })
+      ws._handleCandleMessage([64, [
+        [5, 100, 70, 150, 30, 1000],
+        [2, 200, 90, 150, 30, 1000],
+        [1, 130, 90, 150, 30, 1000],
+        [4, 104, 80, 150, 30, 1000]
+      ]], ws._channelMap[64])
 
-      ws._handleInfoEvent({ version: 3 })
+      const candles = ws._candles['trade:1m:tBTCUSD']
+
+      // maintains sort
+      assert.strictEqual(candles.length, 4)
+      assert.strictEqual(candles[0][0], 5)
+      assert.strictEqual(candles[1][0], 4)
+      assert.strictEqual(candles[2][0], 2)
+      assert.strictEqual(candles[3][0], 1)
+
+      // updates existing candle
+      ws._handleCandleMessage([
+        64,
+        [5, 200, 20, 220, 20, 2000]
+      ], ws._channelMap[64])
+
+      assert.deepStrictEqual(candles[0], [5, 200, 20, 220, 20, 2000])
+
+      // inserts new candle
+      ws._handleCandleMessage([
+        64,
+        [10, 300, 20, 450, 10, 4000]
+      ], ws._channelMap[64])
+
+      assert.deepStrictEqual(candles[0], [10, 300, 20, 450, 10, 4000])
+    })
+
+    it('_handleCandleMessage: emits error on internal candle update failure', (done) => {
+      ws = new WSv2({ manageCandles: true })
+      ws._channelMap = {
+        42: {
+          channel: 'candles',
+          key: 'trade:30m:tBTCUSD'
+        },
+
+        64: {
+          channel: 'candles',
+          key: 'trade:1m:tBTCUSD'
+        }
+      }
+
+      let errorsSeen = 0
+
+      ws.on('error', () => {
+        if (++errorsSeen === 1) done()
+      })
+
+      ws._handleCandleMessage([64, [
+        [5, 100, 70, 150, 30, 1000],
+        [2, 200, 90, 150, 30, 1000],
+        [1, 130, 90, 150, 30, 1000],
+        [4, 104, 80, 150, 30, 1000]
+      ]], ws._channelMap[64])
+
+      // update for unknown key
+      ws._handleCandleMessage([
+        42,
+        [5, 10, 70, 150, 30, 10]
+      ], ws._channelMap[42])
+    })
+
+    it('_handleCandleMessage: forwards managed candles to listeners', (done) => {
+      ws = new WSv2({ manageCandles: true })
+      ws._channelMap = {
+        42: {
+          chanId: 42,
+          channel: 'candles',
+          key: 'trade:1m:tBTCUSD'
+        }
+      }
+
+      let seen = 0
+      ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (data) => {
+        assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
+        if (++seen === 2) done()
+      })
+
+      ws.onCandle({}, (data) => {
+        assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
+        if (++seen === 2) done()
+      })
+
+      ws._handleCandleMessage([
+        42,
+        [[5, 10, 70, 150, 30, 10]]
+      ], ws._channelMap[42])
+    })
+
+    it('_handleCandleMessage: emits managed candles', () => {
+      let seenCandle = false
+      ws = new WSv2({ manageCandles: true })
+      ws._channelMap = {
+        42: {
+          channel: 'candles',
+          key: 'trade:1m:tBTCUSD'
+        }
+      }
+
+      ws.on('candle', (data, key) => {
+        assert.strictEqual(key, 'trade:1m:tBTCUSD')
+        assert.deepStrictEqual(data, [[5, 10, 70, 150, 30, 10]])
+        seenCandle = true
+      })
+
+      ws._handleCandleMessage([
+        42,
+        [[5, 10, 70, 150, 30, 10]]
+      ], ws._channelMap[42])
+
+      assert(seenCandle)
+    })
+
+    it('_handleCandleMessage: forwards transformed data if transform enabled', () => {
+      let seenCandle = false
+      ws = new WSv2({ transform: true })
+      ws._channelMap = {
+        42: {
+          chanId: 42,
+          channel: 'candles',
+          key: 'trade:1m:tBTCUSD'
+        }
+      }
+
+      ws.onCandle({ key: 'trade:1m:tBTCUSD' }, (candles) => {
+        assert.strictEqual(candles.length, 1)
+        assert.deepStrictEqual(candles[0], {
+          mts: 5,
+          open: 10,
+          close: 70,
+          high: 150,
+          low: 30,
+          volume: 10
+        })
+
+        seenCandle = true
+      })
+
+      ws._handleCandleMessage([
+        42,
+        [[5, 10, 70, 150, 30, 10]]
+      ], ws._channelMap[42])
+
+      assert(seenCandle)
+    })
+
+    it('_updateManagedCandles: returns an error on update for unknown key', () => {
+      ws = createTestWSv2Instance()
+      ws._candles['trade:1m:tBTCUSD'] = []
+
+      const err = ws._updateManagedCandles('trade:30m:tBTCUSD', [
+        1, 10, 70, 150, 30, 10
+      ])
+
+      assert(err)
+      assert(err instanceof Error)
+    })
+
+    it('_updateManagedCandles: correctly maintains transformed OBs', () => {
+      ws = new WSv2({ transform: true })
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        [1, 10, 70, 150, 30, 10],
+        [2, 10, 70, 150, 30, 10]
+      ]))
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        2, 10, 70, 150, 30, 500
+      ]))
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        3, 100, 70, 150, 30, 10
+      ]))
+
+      const candles = ws._candles['trade:1m:tBTCUSD']
+
+      assert.strictEqual(candles.length, 3)
+      assert.deepStrictEqual(candles[0], [
+        3, 100, 70, 150, 30, 10
+      ])
+
+      assert.deepStrictEqual(candles[1], [
+        2, 10, 70, 150, 30, 500
+      ])
+
+      assert.deepStrictEqual(candles[2], [
+        1, 10, 70, 150, 30, 10
+      ])
+    })
+
+    it('_updateManagedCandles: correctly maintains non-transformed OBs', () => {
+      ws = createTestWSv2Instance()
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        [1, 10, 70, 150, 30, 10],
+        [2, 10, 70, 150, 30, 10]
+      ]))
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        2, 10, 70, 150, 30, 500
+      ]))
+
+      assert(!ws._updateManagedCandles('trade:1m:tBTCUSD', [
+        3, 100, 70, 150, 30, 10
+      ]))
+
+      const candles = ws._candles['trade:1m:tBTCUSD']
+
+      assert.strictEqual(candles.length, 3)
+      assert.deepStrictEqual(candles[0], [
+        3, 100, 70, 150, 30, 10
+      ])
+
+      assert.deepStrictEqual(candles[1], [
+        2, 10, 70, 150, 30, 500
+      ])
+
+      assert.deepStrictEqual(candles[2], [
+        1, 10, 70, 150, 30, 10
+      ])
     })
   })
 
-  it('_flushOrderOps: returned promise rejects if not authorised', (done) => {
-    const ws = new WSv2()
-    ws._orderOpBuffer = [
-      [0, 'oc', null, []]
-    ]
+  describe('event msg handling', () => {
+    it('_handleErrorEvent: emits error', (done) => {
+      ws = createTestWSv2Instance()
+      ws.on('error', (err) => {
+        if (err === 42) done()
+      })
+      ws._handleErrorEvent(42)
+    })
 
-    ws._flushOrderOps().catch(() => done())
+    it('_handleConfigEvent: emits error if config failed', (done) => {
+      ws = createTestWSv2Instance()
+      ws.on('error', (err) => {
+        if (err.message.indexOf('42') !== -1) done()
+      })
+      ws._handleConfigEvent({ status: 'bad', flags: 42 })
+    })
+
+    it('_handleAuthEvent: emits an error on auth fail', (done) => {
+      ws = createTestWSv2Instance()
+      ws.on('error', () => {
+        done()
+      })
+      ws._handleAuthEvent({ status: 'FAIL' })
+    })
+
+    it('_handleAuthEvent: updates auth flag on auth success', () => {
+      ws = createTestWSv2Instance()
+      assert(!ws.isAuthenticated())
+      ws._handleAuthEvent({ status: 'OK' })
+      assert(ws.isAuthenticated())
+    })
+
+    it('_handleAuthEvent: adds auth channel to channel map', () => {
+      ws = createTestWSv2Instance()
+      assert(Object.keys(ws._channelMap).length === 0)
+      ws._handleAuthEvent({ chanId: 42, status: 'OK' })
+      assert(ws._channelMap[42])
+      assert.strictEqual(ws._channelMap[42].channel, 'auth')
+    })
+
+    it('_handleAuthEvent: emits auth message', (done) => {
+      ws = createTestWSv2Instance()
+      ws.once('auth', (msg) => {
+        assert.strictEqual(msg.chanId, 0)
+        assert.strictEqual(msg.status, 'OK')
+        done()
+      })
+      ws._handleAuthEvent({ chanId: 0, status: 'OK' })
+    })
+
+    it('_handleSubscribedEvent: adds channel to channel map', () => {
+      ws = createTestWSv2Instance()
+      assert(Object.keys(ws._channelMap).length === 0)
+      ws._handleSubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
+      assert(ws._channelMap[42])
+      assert.strictEqual(ws._channelMap[42].chanId, 42)
+      assert.strictEqual(ws._channelMap[42].channel, 'test')
+      assert.strictEqual(ws._channelMap[42].extra, 'stuff')
+    })
+
+    it('_handleUnsubscribedEvent: removes channel from channel map', () => {
+      ws = createTestWSv2Instance()
+      assert(Object.keys(ws._channelMap).length === 0)
+      ws._handleSubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
+      ws._handleUnsubscribedEvent({ chanId: 42, channel: 'test', extra: 'stuff' })
+      assert(Object.keys(ws._channelMap).length === 0)
+    })
+
+    it('_handleInfoEvent: passes message to relevant listeners (raw access)', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      let n = 0
+
+      ws._infoListeners[42] = [
+        () => { n += 1 },
+        () => { n += 2 }
+      ]
+
+      ws._handleInfoEvent({ code: 42 })
+
+      assert.strictEqual(n, 3)
+    })
+
+    it('_handleInfoEvent: passes message to relevant listeners', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      let n = 0
+
+      ws.onInfoMessage(42, () => { n += 1 })
+      ws.onInfoMessage(42, () => { n += 2 })
+      ws._handleInfoEvent({ code: 42 })
+
+      assert.strictEqual(n, 3)
+      wss.close()
+    })
+
+    it('_handleInfoEvent: passes message to relevant named listeners', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      let n = 0
+
+      ws.onServerRestart(() => { n += 1 })
+      ws.onMaintenanceStart(() => { n += 10 })
+      ws.onMaintenanceEnd(() => { n += 100 })
+
+      ws._handleInfoEvent({ code: WSv2.info.SERVER_RESTART })
+      ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_START })
+      ws._handleInfoEvent({ code: WSv2.info.MAINTENANCE_END })
+
+      assert.strictEqual(n, 111)
+      wss.close()
+    })
+
+    it('_handleInfoEvent: closes & emits error if not on api v2', async () => {
+      wss = new MockWSv2Server()
+      ws = createTestWSv2Instance()
+
+      await ws.open()
+
+      return new Promise((resolve) => {
+        let seen = 0
+
+        ws.on('error', () => { if (++seen === 2) { resolve() } })
+        ws.on('close', () => { if (++seen === 2) { resolve() } })
+
+        ws._handleInfoEvent({ version: 3 })
+      })
+    })
+
+    it('_flushOrderOps: returned promise rejects if not authorised', async () => {
+      ws = createTestWSv2Instance()
+      ws._orderOpBuffer = [[0, 'oc', null, []]]
+
+      try {
+        ws._flushOrderOps()
+        assert(false)
+      } catch (e) {}
+    })
+
+    it('_flushOrderOps: merges the buffer into a multi-op packet & sends', (done) => {
+      ws = createTestWSv2Instance()
+      ws._isAuthenticated = true
+
+      ws._orderOpBuffer = [
+        [0, 'oc', null, []],
+        [0, 'on', null, []],
+        [0, 'oc_multi', null, []],
+        [0, 'ou', null, []]
+      ]
+
+      ws.send = (packet) => {
+        assert.strictEqual(packet[1], 'ox_multi')
+        assert.strictEqual(packet[3].length, 4)
+        done()
+      }
+
+      ws._flushOrderOps().catch(() => assert(false))
+    })
+
+    it('_flushOrderOps: splits up buffers greater than 15 ops in size', async () => {
+      ws = createTestWSv2Instance()
+      ws._isAuthenticated = true
+
+      let seenCount = 0
+      let seenAll = false
+
+      for (let i = 0; i < 45; i++) {
+        ws._orderOpBuffer.push([0, 'oc', null, []])
+      }
+
+      ws.send = (packet) => {
+        assert.strictEqual(packet[1], 'ox_multi')
+        assert(packet[3].length <= 15)
+        seenCount += packet[3].length
+
+        if (seenCount === 45) {
+          seenAll = true
+        }
+      }
+
+      try {
+        await ws._flushOrderOps()
+        assert(false)
+      } catch (e) {}
+
+      assert(seenAll)
+    })
   })
 
-  it('_flushOrderOps: merges the buffer into a multi-op packet & sends', (done) => {
-    const ws = new WSv2()
-    ws._isAuthenticated = true
+  describe('WSv2 packet watch-dog', () => {
+    it('resets the WD timeout on every websocket message', (done) => {
+      ws = new WSv2({ packetWDDelay: 1000 })
+      assert.strictEqual(ws._packetWDTimeout, null)
 
-    ws._orderOpBuffer = [
-      [0, 'oc', null, []],
-      [0, 'on', null, []],
-      [0, 'oc_multi', null, []],
-      [0, 'ou', null, []]
-    ]
+      ws.on('error', () => {}) // ignore json errors
 
-    ws.send = (packet) => {
-      assert.strictEqual(packet[1], 'ox_multi')
-      assert.strictEqual(packet[3].length, 4)
-      done()
-    }
+      let wdResets = 0
+      ws._resetPacketWD = () => {
+        if (++wdResets === 4) done()
+      }
 
-    ws._flushOrderOps().catch(() => assert(false))
-  })
-
-  it('_flushOrderOps: splits up buffers greater than 15 ops in size', (done) => {
-    const ws = new WSv2()
-    ws._isAuthenticated = true
-
-    let seenCount = 0
-
-    for (let i = 0; i < 45; i++) {
-      ws._orderOpBuffer.push([0, 'oc', null, []])
-    }
-
-    ws.send = (packet) => {
-      assert.strictEqual(packet[1], 'ox_multi')
-      assert(packet[3].length <= 15)
-      seenCount += packet[3].length
-
-      if (seenCount === 45) done()
-    }
-
-    ws._flushOrderOps().catch(() => assert(false))
-  })
-})
-
-describe('WSv2 packet watch-dog', () => {
-  it('resets the WD timeout on every websocket message', (done) => {
-    const ws = new WSv2({ packetWDDelay: 1000 })
-    assert.strictEqual(ws._packetWDTimeout, null)
-
-    ws.on('error', () => {}) // ignore json errors
-
-    let wdResets = 0
-    ws._resetPacketWD = () => {
-      if (++wdResets === 4) done()
-    }
-
-    ws._onWSMessage('asdf')
-    ws._onWSMessage('asdf')
-    ws._onWSMessage('asdf')
-    ws._onWSMessage('asdf')
-  })
-
-  it('_resetPacketWD: clears existing wd timeout', (done) => {
-    const ws = new WSv2({ packetWDDelay: 1000 })
-    ws._packetWDTimeout = setTimeout(() => {
-      assert(false)
-    }, 100)
-
-    ws._resetPacketWD()
-    setTimeout(done, 200)
-  })
-
-  it('_resetPacketWD: schedules new wd timeout', (done) => {
-    const ws = new WSv2({ packetWDDelay: 500 })
-    ws._isOpen = true
-    ws._triggerPacketWD = () => done()
-    ws._resetPacketWD()
-    assert(ws._packetWDTimeout !== null)
-  })
-
-  it('_triggerPacketWD: does nothing if wd is disabled', (done) => {
-    const ws = new WSv2()
-    ws._isOpen = true
-    ws.reconnect = () => assert(false)
-    ws._triggerPacketWD()
-
-    setTimeout(() => {
-      done()
-    }, 50)
-  })
-
-  it('_triggerPacketWD: calls reconnect()', (done) => {
-    const ws = new WSv2({ packetWDDelay: 1000 })
-    ws._isOpen = true
-    ws.reconnect = () => done()
-    ws._triggerPacketWD()
-  })
-
-  it('triggers wd when no packet arrives after delay elapses', (done) => {
-    const ws = new WSv2({ packetWDDelay: 100 })
-    const now = Date.now()
-    ws._isOpen = true
-
-    ws.on('error', () => {}) // invalid json to prevent message routing
-    ws._triggerPacketWD = function () {
-      assert((Date.now() - now) >= 95)
-      done()
-
-      return Promise.resolve()
-    }
-
-    ws._triggerPacketWD = ws._triggerPacketWD.bind(ws)
-    ws._onWSMessage('asdf') // send first packet, init wd
-  })
-
-  it('doesn\'t trigger wd when packets arrive as expected', (done) => {
-    const ws = new WSv2({ packetWDDelay: 100 })
-    ws._isOpen = true
-
-    ws.on('error', () => {}) // invalid json to prevent message routing
-
-    const sendInterval = setInterval(() => {
       ws._onWSMessage('asdf')
-    }, 50)
+      ws._onWSMessage('asdf')
+      ws._onWSMessage('asdf')
+      ws._onWSMessage('asdf')
+    })
 
-    ws._triggerPacketWD = () => assert(false)
-    ws._onWSMessage('asdf')
+    it('_resetPacketWD: clears existing wd timeout', (done) => {
+      ws = new WSv2({ packetWDDelay: 1000 })
+      ws._packetWDTimeout = setTimeout(() => {
+        assert(false)
+      }, 100)
 
-    setTimeout(() => {
+      ws._resetPacketWD()
+      setTimeout(done, 200)
+    })
+
+    it('_resetPacketWD: schedules new wd timeout', (done) => {
+      ws = new WSv2({ packetWDDelay: 500 })
+      ws._isOpen = true
+      ws._triggerPacketWD = () => done()
+      ws._resetPacketWD()
+      assert(ws._packetWDTimeout !== null)
+    })
+
+    it('_triggerPacketWD: does nothing if wd is disabled', (done) => {
+      ws = createTestWSv2Instance()
+      ws._isOpen = true
+      ws.reconnect = () => assert(false)
+      ws._triggerPacketWD()
+
+      setTimeout(done, 50)
+    })
+
+    it('_triggerPacketWD: calls reconnect()', (done) => {
+      ws = new WSv2({ packetWDDelay: 1000 })
+      ws._isOpen = true
+      ws.reconnect = done
+      ws._triggerPacketWD()
+    })
+
+    it('triggers wd when no packet arrives after delay elapses', async () => {
+      const now = Date.now()
+      let wdTriggered = false
+
+      ws = new WSv2({ packetWDDelay: 100 })
+      ws._isOpen = true
+
+      ws.on('error', () => {}) // invalid json to prevent message routing
+      ws._triggerPacketWD = () => {
+        assert((Date.now() - now) >= 95)
+        wdTriggered = true
+
+        return Promise.resolve()
+      }
+
+      ws._triggerPacketWD = ws._triggerPacketWD.bind(ws)
+      ws._onWSMessage('asdf') // send first packet, init wd
+
+      await new Promise(resolve => setTimeout(resolve, 150))
+
+      assert(wdTriggered)
+    })
+
+    it('doesn\'t trigger wd when packets arrive as expected', async () => {
+      ws = new WSv2({ packetWDDelay: 100 })
+      ws._isOpen = true
+
+      ws.on('error', () => {}) // invalid json to prevent message routing
+
+      const sendInterval = setInterval(() => {
+        ws._onWSMessage('asdf')
+      }, 50)
+
+      ws._triggerPacketWD = () => assert(false)
+      ws._onWSMessage('asdf')
+
+      await new Promise(resolve => setTimeout(resolve, 200))
+
       clearInterval(sendInterval)
       clearTimeout(ws._packetWDTimeout)
-      done()
-    }, 200)
+    })
   })
-})
 
-describe('WSv2 message sending', () => {
-  it('emits error if no client available or open', (done) => {
-    const ws = new WSv2()
+  describe('message sending', () => {
+    it('emits error if no client available or open', async () => {
+      ws = createTestWSv2Instance()
 
-    ws.on('error', (e) => {
-      if (e.message.indexOf('no ws client') === -1) {
-        done(new Error('received unexpected error'))
-      } else {
-        done()
+      return new Promise((resolve) => {
+        ws.on('error', (e) => {
+          if (e.message.indexOf('no ws client') === -1) {
+            throw new Error('received unexpected error')
+          } else {
+            resolve()
+          }
+        })
+
+        ws.send({})
+      })
+    })
+
+    it('emits error if connection is closing', async () => {
+      ws = createTestWSv2Instance()
+
+      ws._ws = true
+      ws._isOpen = true
+      ws._isClosing = true
+
+      return new Promise((resolve) => {
+        ws.on('error', (e) => {
+          if (e.message.indexOf('currently closing') === -1) {
+            throw new Error('received unexpected error')
+          } else {
+            resolve()
+          }
+        })
+
+        ws.send({})
+      })
+    })
+
+    it('sends stringified payload', async () => {
+      ws = createTestWSv2Instance()
+
+      ws._isOpen = true
+      ws._isClosing = false
+
+      return new Promise((resolve) => {
+        ws._ws = {
+          send: (json) => {
+            const msg = JSON.parse(json)
+
+            assert.strictEqual(msg.a, 42)
+            resolve()
+          }
+        }
+
+        ws.send({ a: 42 })
+      })
+    })
+  })
+
+  describe('WSv2 seq audit: _validateMessageSeq', () => {
+    it('returns an error on invalid pub seq', () => {
+      ws = createTestWSv2Instance()
+
+      ws._seqAudit = true
+      ws._lastPubSeq = 0
+
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 1]), null)
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 2]), null)
+
+      const err = ws._validateMessageSeq([243, [252.12, 2, -1], 5])
+      assert(err instanceof Error)
+    })
+
+    it('returns an error on invalid auth seq', () => {
+      ws = createTestWSv2Instance()
+
+      ws._seqAudit = true
+      ws._lastPubSeq = 0
+      ws._lastAuthSeq = 0
+
+      assert.strictEqual(ws._validateMessageSeq([0, [252.12, 2, -1], 1, 1]), null)
+      assert.strictEqual(ws._validateMessageSeq([0, [252.12, 2, -1], 2, 2]), null)
+
+      const err = ws._validateMessageSeq([0, [252.12, 2, -1], 3, 5])
+      assert(err instanceof Error)
+    })
+
+    it('ignores heartbeats', () => {
+      ws = createTestWSv2Instance()
+
+      ws._seqAudit = true
+      ws._lastPubSeq = 0
+
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 1]), null)
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 2]), null)
+      assert.strictEqual(ws._validateMessageSeq([243, 'hb']), null)
+      assert.strictEqual(ws._validateMessageSeq([243, 'hb']), null)
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 3]), null)
+      assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 4]), null)
+    })
+
+    it('ignores auth seq for notifications', () => {
+      ws = createTestWSv2Instance()
+
+      ws._seqAudit = true
+      ws._lastPubSeq = 0
+      ws._lastAuthSeq = 0
+
+      const nSuccess = [null, null, null, null, null, null, 'SUCCESS']
+      const nError = [null, null, null, null, null, null, 'ERROR']
+
+      assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 1, 1]), null)
+      assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 2, 2]), null)
+      assert.strictEqual(ws._validateMessageSeq([0, 'n', nError, 3, 2]), null)
+      assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 4, 3]), null)
+      assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 5, 4]), null)
+    })
+  })
+
+  describe('_handleTradeMessage', () => {
+    it('correctly forwards payloads w/ seq numbers', () => {
+      ws = createTestWSv2Instance()
+
+      const payload = [
+        [286614318, 1535531325604, 0.05, 7073.51178714],
+        [286614249, 1535531321436, 0.0215938, 7073.6],
+        [286614248, 1535531321430, 0.0284062, 7073.51178714]
+      ]
+
+      const msg = [1710, payload, 1]
+      let sawTrade = false
+
+      ws.onTrades({ pair: 'tBTCUSD' }, (data) => {
+        assert.deepStrictEqual(data, payload)
+        sawTrade = true
+      })
+
+      ws._handleTradeMessage(msg, {
+        channel: 'trades',
+        pair: 'tBTCUSD'
+      })
+
+      assert(sawTrade)
+    })
+
+    it('correctly forwards funding trades', () => {
+      ws = createTestWSv2Instance()
+
+      const payload = [
+        [286614318, 1535531325604, 0.05, 7073.51178714],
+        [286614249, 1535531321436, 0.0215938, 7073.6],
+        [286614248, 1535531321430, 0.0284062, 7073.51178714]
+      ]
+
+      const msg = [1710, payload, 1]
+      let sawTrade = false
+
+      ws.onTrades({ pair: 'fUSD' }, (data) => {
+        assert.deepStrictEqual(data, payload)
+        sawTrade = true
+      })
+
+      ws._handleTradeMessage(msg, {
+        channel: 'trades',
+        pair: 'fUSD'
+      })
+
+      assert(sawTrade)
+    })
+
+    it('correctly routes fte packets', () => {
+      ws = createTestWSv2Instance()
+
+      const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
+      const msg = [0, 'fte', payload]
+      let sawFTE = false
+
+      ws.onFundingTradeEntry({ pair: 'tBTCUSD' }, (data) => {
+        assert.deepStrictEqual(data[0], payload)
+        sawFTE = true
+      })
+
+      ws._handleTradeMessage(msg, {
+        channel: 'fte',
+        pair: 'tBTCUSD'
+      })
+
+      assert(sawFTE)
+    })
+
+    it('correctly routes ftu packets', () => {
+      ws = createTestWSv2Instance()
+
+      const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
+      const msg = [0, 'ftu', payload]
+      let sawFTU = false
+
+      ws.onFundingTradeUpdate({ pair: 'tBTCUSD' }, (data) => {
+        assert.deepStrictEqual(data[0], payload)
+        sawFTU = true
+      })
+
+      ws._handleTradeMessage(msg, {
+        channel: 'ftu',
+        pair: 'tBTCUSD'
+      })
+
+      assert(sawFTU)
+    })
+  })
+
+  describe('resubscribePreviousChannels', () => {
+    it('resubscribes to channels in prev channel map', () => {
+      ws = createTestWSv2Instance()
+      let subTicker = false
+      let subTrades = false
+      let subBook = false
+      let subCandles = false
+
+      ws._prevChannelMap = {
+        123: { channel: 'ticker', symbol: 'tBTCUSD' },
+        456: { channel: 'trades', symbol: 'tBTCUSD' },
+        789: { channel: 'candles', key: 'trade:1m:tBTCUSD' },
+        42: { channel: 'book', symbol: 'tBTCUSD', prec: 'R0', len: '25' }
       }
-    })
 
-    ws.send({})
-  })
-
-  it('emits error if connection is closing', (done) => {
-    const ws = new WSv2()
-
-    ws._ws = true
-    ws._isOpen = true
-    ws._isClosing = true
-
-    ws.on('error', (e) => {
-      if (e.message.indexOf('currently closing') === -1) {
-        done(new Error('received unexpected error'))
-      } else {
-        done()
+      ws.subscribeTicker = (sym) => {
+        assert.strictEqual(sym, 'tBTCUSD')
+        subTicker = true
       }
-    })
 
-    ws.send({})
-  })
-
-  it('sends stringified payload', (done) => {
-    const ws = new WSv2()
-
-    ws._isOpen = true
-    ws._isClosing = false
-    ws._ws = {
-      send: (json) => {
-        const msg = JSON.parse(json)
-
-        assert.strictEqual(msg.a, 42)
-        done()
+      ws.subscribeTrades = (sym) => {
+        assert.strictEqual(sym, 'tBTCUSD')
+        subTrades = true
       }
-    }
 
-    ws.send({ a: 42 })
-  })
-})
+      ws.subscribeCandles = (key) => {
+        assert.strictEqual(key, 'trade:1m:tBTCUSD')
+        subCandles = true
+      }
 
-describe('WSv2 seq audit: _validateMessageSeq', () => {
-  it('returns an error on invalid pub seq', () => {
-    const ws = new WSv2()
+      ws.subscribeOrderBook = (sym, prec, len) => {
+        assert.strictEqual(sym, 'tBTCUSD')
+        assert.strictEqual(prec, 'R0')
+        assert.strictEqual(len, '25')
+        subBook = true
+      }
 
-    ws._seqAudit = true
-    ws._lastPubSeq = 0
+      ws.resubscribePreviousChannels()
 
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 1]), null)
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 2]), null)
-
-    const err = ws._validateMessageSeq([243, [252.12, 2, -1], 5])
-    assert(err instanceof Error)
-  })
-
-  it('returns an error on invalid auth seq', () => {
-    const ws = new WSv2()
-
-    ws._seqAudit = true
-    ws._lastPubSeq = 0
-    ws._lastAuthSeq = 0
-
-    assert.strictEqual(ws._validateMessageSeq([0, [252.12, 2, -1], 1, 1]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, [252.12, 2, -1], 2, 2]), null)
-
-    const err = ws._validateMessageSeq([0, [252.12, 2, -1], 3, 5])
-    assert(err instanceof Error)
-  })
-
-  it('ignores heartbeats', () => {
-    const ws = new WSv2()
-
-    ws._seqAudit = true
-    ws._lastPubSeq = 0
-
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 1]), null)
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 2]), null)
-    assert.strictEqual(ws._validateMessageSeq([243, 'hb']), null)
-    assert.strictEqual(ws._validateMessageSeq([243, 'hb']), null)
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 3]), null)
-    assert.strictEqual(ws._validateMessageSeq([243, [252.12, 2, -1], 4]), null)
-  })
-
-  it('ignores auth seq for notifications', () => {
-    const ws = new WSv2()
-
-    ws._seqAudit = true
-    ws._lastPubSeq = 0
-    ws._lastAuthSeq = 0
-
-    const nSuccess = [null, null, null, null, null, null, 'SUCCESS']
-    const nError = [null, null, null, null, null, null, 'ERROR']
-
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 1, 1]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 2, 2]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nError, 3, 2]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 4, 3]), null)
-    assert.strictEqual(ws._validateMessageSeq([0, 'n', nSuccess, 5, 4]), null)
-  })
-})
-
-describe('_handleTradeMessage', () => {
-  it('correctly forwards payloads w/ seq numbers', (done) => {
-    const ws = new WSv2()
-    const payload = [
-      [286614318, 1535531325604, 0.05, 7073.51178714],
-      [286614249, 1535531321436, 0.0215938, 7073.6],
-      [286614248, 1535531321430, 0.0284062, 7073.51178714]
-    ]
-    const msg = [1710, payload, 1]
-
-    ws.onTrades({ pair: 'tBTCUSD' }, (data) => {
-      assert.deepStrictEqual(data, payload)
-      done()
-    })
-
-    ws._handleTradeMessage(msg, {
-      channel: 'trades',
-      pair: 'tBTCUSD'
+      assert(subTicker)
+      assert(subTrades)
+      assert(subCandles)
+      assert(subBook)
     })
   })
 
-  it('correctly forwards funding trades', (done) => {
-    const ws = new WSv2()
-    const payload = [
-      [286614318, 1535531325604, 0.05, 7073.51178714],
-      [286614249, 1535531321436, 0.0215938, 7073.6],
-      [286614248, 1535531321430, 0.0284062, 7073.51178714]
-    ]
-    const msg = [1710, payload, 1]
-
-    ws.onTrades({ pair: 'fUSD' }, (data) => {
-      assert.deepStrictEqual(data, payload)
-      done()
+  describe('auth args', () => {
+    it('provides getAuthArgs to read args', () => {
+      ws = createTestWSv2Instance()
+      ws.updateAuthArgs({ dms: 4 })
+      assert.strictEqual(ws.getAuthArgs().dms, 4)
     })
 
-    ws._handleTradeMessage(msg, {
-      channel: 'trades',
-      pair: 'fUSD'
-    })
-  })
+    it('initializes to empty args set', () => {
+      ws = createTestWSv2Instance()
+      const initAuthArgs = ws.getAuthArgs()
 
-  it('correctly routes fte packets', (done) => {
-    const ws = new WSv2()
-    const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
-    const msg = [0, 'fte', payload]
-
-    ws.onFundingTradeEntry({ pair: 'tBTCUSD' }, (data) => {
-      assert.deepStrictEqual(data[0], payload)
-      done()
+      assert(_isObject(initAuthArgs) && _isEmpty(initAuthArgs))
     })
 
-    ws._handleTradeMessage(msg, {
-      channel: 'fte',
-      pair: 'tBTCUSD'
+    it('updates auth args with setAuthArgs', async () => {
+      ws = createTestWSv2Instance()
+      wss = new MockWSv2Server()
+      let sendCalled = false
+
+      await ws.open()
+
+      ws.updateAuthArgs({ dms: 4 })
+      assert.strictEqual(ws.getAuthArgs().dms, 4)
+
+      ws.send = (payload) => {
+        assert.strictEqual(payload.dms, 4)
+        sendCalled = true
+        ws.emit('auth')
+      }
+
+      ws.auth() // note promise ignored
+      assert(sendCalled)
     })
-  })
-
-  it('correctly routes ftu packets', (done) => {
-    const ws = new WSv2()
-    const payload = [636854, 'fUSD', 1575282446000, 41238905, -1000, 0.002, 7, null]
-    const msg = [0, 'ftu', payload]
-
-    ws.onFundingTradeUpdate({ pair: 'tBTCUSD' }, (data) => {
-      assert.deepStrictEqual(data[0], payload)
-      done()
-    })
-
-    ws._handleTradeMessage(msg, {
-      channel: 'ftu',
-      pair: 'tBTCUSD'
-    })
-  })
-})
-
-describe('resubscribePreviousChannels', async () => {
-  it('resubscribes to channels in prev channel map', () => {
-    const ws = new WSv2()
-    let subTicker = false
-    let subTrades = false
-    let subBook = false
-    let subCandles = false
-
-    ws._prevChannelMap = {
-      123: { channel: 'ticker', symbol: 'tBTCUSD' },
-      456: { channel: 'trades', symbol: 'tBTCUSD' },
-      789: { channel: 'candles', key: 'trade:1m:tBTCUSD' },
-      42: { channel: 'book', symbol: 'tBTCUSD', prec: 'R0', len: '25' }
-    }
-
-    ws.subscribeTicker = (sym) => {
-      assert.strictEqual(sym, 'tBTCUSD')
-      subTicker = true
-    }
-
-    ws.subscribeTrades = (sym) => {
-      assert.strictEqual(sym, 'tBTCUSD')
-      subTrades = true
-    }
-
-    ws.subscribeCandles = (key) => {
-      assert.strictEqual(key, 'trade:1m:tBTCUSD')
-      subCandles = true
-    }
-
-    ws.subscribeOrderBook = (sym, prec, len) => {
-      assert.strictEqual(sym, 'tBTCUSD')
-      assert.strictEqual(prec, 'R0')
-      assert.strictEqual(len, '25')
-      subBook = true
-    }
-
-    ws.resubscribePreviousChannels()
-
-    assert(subTicker)
-    assert(subTrades)
-    assert(subCandles)
-    assert(subBook)
-  })
-})
-
-describe('WSv2 auth args', () => {
-  it('provides getAuthArgs to read args', () => {
-    const ws = new WSv2()
-    ws.updateAuthArgs({ dms: 4 })
-    assert.strictEqual(ws.getAuthArgs().dms, 4)
-  })
-
-  it('initializes to empty args set', () => {
-    const ws = new WSv2()
-    const initAuthArgs = ws.getAuthArgs()
-
-    assert(_isObject(initAuthArgs) && _isEmpty(initAuthArgs))
-  })
-
-  it('updates auth args with setAuthArgs', async () => {
-    const ws = new WSv2()
-    const wss = new MockWSv2Server()
-    let sendCalled = false
-
-    await ws.open()
-
-    ws.updateAuthArgs({ dms: 4 })
-    assert.strictEqual(ws.getAuthArgs().dms, 4)
-
-    ws.send = (payload) => {
-      assert.strictEqual(payload.dms, 4)
-      sendCalled = true
-      ws.emit('auth')
-    }
-
-    await ws.auth()
-    assert(sendCalled)
-
-    wss.close()
   })
 })


### PR DESCRIPTION
Needs https://github.com/bitfinexcom/bfx-api-mock-srv/pull/29

### New Features:
- [x] Channel filters now support `'*'` values to match against all field values

### Fixes:
- [x] Tweak tests so they can be run concurrently along all other HF/API libraries
- [x] removes vestigial comments
- [x] minor linting fixes

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
