### PR TITLE
Fix: Move readline-promise to deps from dev-deps 4.0.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.12
+- meta: mv readline-promise to deps from dev-deps
+
 4.0.11
 - meta: added nyc for coverage file gen
 - meta: added husky npm test pre-commit hook

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "readline-promise": "^1.0.4",
-    "bfx-api-node-models": "^1.2.0",
+    "bfx-api-node-models": "^1.2.1",
     "bfx-api-node-rest": "^3.0.8",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=8.3.0"
@@ -63,13 +63,13 @@
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^7.1.0",
     "nyc": "^15.0.0",
-    "readline-promise": "^1.0.4",
     "socks-proxy-agent": "^5.0.0",
     "standard": "^14.3.1"
   },
   "dependencies": {
+    "readline-promise": "^1.0.4",
     "bfx-api-node-models": "^1.2.0",
-    "bfx-api-node-rest": "^3.0.4",
+    "bfx-api-node-rest": "^3.0.8",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
     "bignumber.js": "^9.0.0",


### PR DESCRIPTION
### Description:
Moves `readline-promise` to deps from dev-deps for `bfx-cli` (normally it's a dev dep for this repo, but bfx-cli utilizes the examples).

Also bumps `bfx-api-node-rest` and `bfx-api-node-models` for travis.

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Documentation updated
