### PR TITLE
Fixed bug reported #546

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -8,6 +8,7 @@ const CbQ = require('cbq')
 const _Throttle = require('lodash.throttle') // eslint-disable-line
 const _isArray = require('lodash/isArray')
 const _isEmpty = require('lodash/isEmpty')
+const _isUndefined = require('lodash/isUndefined')
 const _isString = require('lodash/isString')
 const _isNumber = require('lodash/isNumber')
 const _includes = require('lodash/includes')
@@ -1244,7 +1245,7 @@ class WSv2 extends EventEmitter {
     for (let k = 0; k < filterIndices.length; k++) {
       filterValue = filter[filterIndices[k]]
 
-      if (filterValue === undefined || filterValue === '*') {
+      if (_isUndefined(filterValue) || filterValue === '*') {
         continue
       }
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -1244,7 +1244,7 @@ class WSv2 extends EventEmitter {
     for (let k = 0; k < filterIndices.length; k++) {
       filterValue = filter[filterIndices[k]]
 
-      if (_isEmpty(filterValue) || filterValue === '*') {
+      if (filterValue === undefined || filterValue === '*') {
         continue
       }
 


### PR DESCRIPTION
_isEmpty only works for collections, here you are evaluating an individual item so something like checking for undefined would be best. This fixes my bug reported:
https://github.com/bitfinexcom/bitfinex-api-node/issues/546

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Documentation updated
