### PR TITLE
incorrect use of isEmpty

### DIFF
--- a/examples/ws2/cancel_all.js
+++ b/examples/ws2/cancel_all.js
@@ -27,7 +27,7 @@ module.exports = runExample({
     return debug('no orders to cancel')
   }
 
-  const orders = _isEmpty(filterByMarket)
+  const orders = (filterByMarket === undefined)
     ? allOrders
     : allOrders.filter(o => o.symbol === filterByMarket)
 


### PR DESCRIPTION
isEmpty always returns true as it is not an object. Changed the statement to use === undefined as the variable is declared on top but would be undefined if no value is passed.

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Documentation updated
