### PR TITLE
Fix funding trade field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.16
+- WSv2: fix parse funding trade failed.
+
 4.0.15
 - fix 2 high vulnerabilities, switch from cli-table2 to cli-table3 dependency
 

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -979,13 +979,12 @@ class WSv2 extends EventEmitter {
     let data = payload
 
     if (this._transform) { // correctly parse single trade/array of trades
-      const M = eventName[0] === 'f' ? FundingTrade : PublicTrade
-      const trades = M.unserialize(data)
+      const M = eventName[0] === 'f' && data[0].length === 8 ? FundingTrade : PublicTrade
 
-      if (_isArray(trades) && trades.length === 1) {
-        data = trades[0]
+      if (_isArray(payload) && payload.length === 1) {
+        data = payload[0]
       } else {
-        data = trades
+        data = payload
       }
 
       data = new M(data)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfinex-api-node",
-  "version": "4.0.15",
+  "version": "4.0.16",
   "description": "Node reference library for Bitfinex API",
   "engines": {
     "node": ">=8.3.0"


### PR DESCRIPTION
Signed-off-by: chang-ning <spiderpower02@gmail.com>

### Description:

Parsing a funding trade is incorrect. There are two issues I fixed:

1. FundingTrade has 8 fields ([FundingTrade](https://docs.bitfinex.com/reference#ws-auth-funding-trades))
2. ``M.unserialize`` is unnecessary.

### Fixes:
- [X] Fix Issue #555

### PR status:
- [X] Version bumped
- [X] Change-log updated
- [X] Documentation updated
