### PR TITLE
fix: unsubscribe fails depending on channel id type

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -233,7 +233,7 @@ class WSv2 extends EventEmitter {
    * @returns {boolean} isSubscribed
    */
   hasChannel (chanId) {
-    return _includes(Object.keys(this._channelMap), chanId)
+    return !!this._channelMap[chanId]
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint lib/ examples/ test/ index.js",
     "test": "npm run lint && npm run unit",
-    "unit": "NODE_ENV=test nyc --check-coverage --lines 80 --branches 65 --functions 70 --statements 75 --reporter=lcov --reporter=html mocha -b --recursive",
+    "unit": "NODE_ENV=test mocha -b --recursive",
     "docs": "rm -rf docs && node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
     "build": "babel -q ./index.js -d ./dist && babel -q ./lib -d ./dist/lib && copy package.json dist"
   },
@@ -59,7 +59,6 @@
     "husky": "^4.2.3",
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^7.1.0",
-    "nyc": "^15.0.0",
     "socks-proxy-agent": "^5.0.0",
     "standard": "^14.3.1"
   },

--- a/test/lib/transports/channels.js
+++ b/test/lib/transports/channels.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+
+const WSv2 = require('../../../lib/transports/ws2')
+
+const API_KEY = 'dummy'
+const API_SECRET = 'dummy'
+
+const createTestWSv2Instance = (params = {}) => {
+  return new WSv2({
+    apiKey: API_KEY,
+    apiSecret: API_SECRET,
+    url: 'ws://localhost:9997',
+    ...params
+  })
+}
+
+describe('WSv2 channels', () => {
+  it('numeric and string channel ids work', () => {
+    const ws = createTestWSv2Instance()
+
+    ws._channelMap = {
+      83297: {
+        event: 'subscribed',
+        channel: 'book',
+        chanId: 83297,
+        symbol: 'tADAUSD',
+        prec: 'P0',
+        freq: 'F0',
+        len: '25',
+        pair: 'ADAUSD'
+      }
+    }
+
+    assert.strictEqual(ws.hasChannel(83297), true)
+    assert.strictEqual(ws.hasChannel('83297'), true)
+    assert.strictEqual(ws.hasChannel('1337'), false)
+    assert.strictEqual(ws.hasChannel(1337), false)
+  })
+})

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -2279,14 +2279,6 @@ describe('WSv2 unit', () => {
     })
   })
 
-  describe('hasChannel', () => {
-    it('returns true if the channel map contains the requested ID', () => {
-      ws = createTestWSv2Instance()
-      ws._channelMap = { test: '' }
-      assert.ok(ws.hasChannel('test'), 'channel ID not recognized')
-    })
-  })
-
   describe('getChannelId', () => {
     it('matches the specified type and filter', () => {
       ws = createTestWSv2Instance()


### PR DESCRIPTION
`Object.keys` casts to strings, channel ids can be are
numbers, the compare function does not cast.

in general its faster to do a direct object access instead of
converting to an array and doing a search on the array.
