### PR TITLE
Fix reconnect

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -96,8 +96,6 @@ class WSv2 extends EventEmitter {
     super()
 
     this.setMaxListeners(1000)
-    this._apiKey = opts.apiKey || ''
-    this._apiSecret = opts.apiSecret || ''
     this._affCode = opts.affCode
     this._agent = opts.agent
     this._url = opts.url || WSv2.url
@@ -117,7 +115,10 @@ class WSv2 extends EventEmitter {
     this._orderBooks = {}
     this._losslessOrderBooks = {}
     this._candles = {}
-    this._authArgs = {}
+    this._authArgs = {
+      apiKey: opts.apiKey,
+      apiSecret: opts.apiSecret
+    }
 
     /**
      * {
@@ -140,7 +141,7 @@ class WSv2 extends EventEmitter {
     this._enabledFlags = this._seqAudit ? WSv2.flags.SEQ_ALL : 0
     this._eventCallbacks = new CbQ()
     this._isAuthenticated = false
-    this._wasEverAuthenticated = false // used for auto-auth on reconnect
+    this._authOnReconnect = false // used for auto-auth on reconnect
     this._lastPubSeq = -1
     this._lastAuthSeq = -1
     this._isOpen = false
@@ -194,19 +195,6 @@ class WSv2 extends EventEmitter {
    */
   getAuthArgs () {
     return this._authArgs
-  }
-
-  /**
-   * Update the internal API credentials, used on subsequent {@link WSv2#auth}
-   * calls
-   *
-   * @param {string} apiKey - API key
-   * @param {string} apiSecret - API secret
-   * @see WSv2#auth
-   */
-  setAPICredentials (apiKey, apiSecret) {
-    this._apiKey = apiKey
-    this._apiSecret = apiSecret
   }
 
   /**
@@ -362,6 +350,7 @@ class WSv2 extends EventEmitter {
    * @returns {Promise} p
    */
   async auth (calc, dms) {
+    this._authOnReconnect = true
     if (!this._isOpen) {
       throw new Error('not open')
     }
@@ -372,7 +361,7 @@ class WSv2 extends EventEmitter {
 
     const authNonce = nonce()
     const authPayload = `AUTH${authNonce}${authNonce}`
-    const { sig } = genAuthSig(this._apiSecret, authPayload)
+    const { sig } = genAuthSig(this._authArgs.apiSecret, authPayload)
     const authArgs = { ...this._authArgs }
 
     if (_isFinite(calc)) authArgs.calc = calc
@@ -386,7 +375,7 @@ class WSv2 extends EventEmitter {
 
       this.send({
         event: 'auth',
-        apiKey: this._apiKey,
+        apiKey: this._authArgs.apiKey,
         authSig: sig,
         authPayload,
         authNonce,
@@ -408,7 +397,7 @@ class WSv2 extends EventEmitter {
       await this.close()
 
       return new Promise((resolve) => {
-        this.once(this._wasEverAuthenticated ? 'auth' : 'open', resolve)
+        this.once(this._authOnReconnect ? 'auth' : 'open', resolve)
       })
     }
 
@@ -425,7 +414,7 @@ class WSv2 extends EventEmitter {
 
     await this.open()
 
-    if (this._wasEverAuthenticated) {
+    if (this._authOnReconnect) {
       await this.auth()
     }
   }
@@ -1358,7 +1347,6 @@ class WSv2 extends EventEmitter {
 
     this._channelMap[chanId] = { channel: 'auth' }
     this._isAuthenticated = true
-    this._wasEverAuthenticated = true
 
     this.emit('auth', data)
     debug('authenticated!')

--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -177,6 +177,8 @@ class WSv2 extends EventEmitter {
    * @param {object} args - arguments
    * @param {number} [args.calc] - calc value
    * @param {number} [args.dms] - dms value, active 4
+   * @param {number} [args.apiKey] API key
+   * @param {number} [args.apiSecret] API secret
    * @see WSv2#auth
    */
   updateAuthArgs (args = {}) {

--- a/lib/ws2_manager.js
+++ b/lib/ws2_manager.js
@@ -201,10 +201,11 @@ class WS2Manager extends EventEmitter {
 
     if (_isFinite(calc)) this._authArgs.calc = calc
     if (_isFinite(dms)) this._authArgs.dms = dms
+    if (apiKey) this._authArgs.apiKey = apiKey
+    if (apiSecret) this._authArgs.apiSecret = apiSecret
 
     this._sockets.forEach(s => {
       if (!s.ws.isAuthenticated()) {
-        s.ws.setAPICredentials(apiKey, apiSecret)
         s.ws.updateAuthArgs(this._authArgs)
         s.ws.auth()
       }

--- a/test/index.js
+++ b/test/index.js
@@ -105,9 +105,9 @@ describe('BFX', () => {
       const ws2 = bfx.ws(2)
 
       assert.strictEqual(ws1._apiKey, 'k')
-      assert.strictEqual(ws2._apiKey, 'k')
+      assert.strictEqual(ws2._authArgs.apiKey, 'k')
       assert.strictEqual(ws1._apiSecret, 's')
-      assert.strictEqual(ws2._apiSecret, 's')
+      assert.strictEqual(ws2._authArgs.apiSecret, 's')
       assert.strictEqual(ws1._url, 'wss://')
       assert.strictEqual(ws2._url, 'wss://')
       assert.strictEqual(ws2._transform, true)

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -565,6 +565,25 @@ describe('WSv2 unit', () => {
     })
   })
 
+  it('reconnect with new credentials', async () => {
+    wss = new MockWSv2Server({ authMiddleware: ({ apiKey, apiSecret }) => apiKey === API_KEY && apiSecret === API_SECRET })
+    ws = createTestWSv2Instance({ reconnectDelay: 10 })
+
+    await ws.open()
+    await ws.auth()
+    assert(ws.isAuthenticated())
+
+    ws.updateAuthArgs({ apiKey: 'wrong', apiSecret: 'wrong' })
+    ws.reconnect()
+    await Promise.delay(50)
+    assert(!ws.isAuthenticated())
+
+    ws.updateAuthArgs({ apiKey: API_KEY, apiSecret: API_SECRET })
+    ws.reconnect()
+    await Promise.delay(50)
+    assert(ws.isAuthenticated())
+  })
+
   describe('seq audit', () => {
     it('automatically enables sequencing if seqAudit is true in constructor', () => {
       ws = createTestWSv2Instance({ seqAudit: true })

--- a/test/lib/transports/ws2-unit.js
+++ b/test/lib/transports/ws2-unit.js
@@ -2024,11 +2024,15 @@ describe('WSv2 unit', () => {
       assert.strictEqual(ws.getAuthArgs().dms, 4)
     })
 
-    it('initializes to empty args set', () => {
+    it('initializes auth args', () => {
       ws = createTestWSv2Instance()
       const initAuthArgs = ws.getAuthArgs()
 
-      assert(_isObject(initAuthArgs) && _isEmpty(initAuthArgs))
+      assert(_isObject(initAuthArgs))
+      assert.deepStrictEqual(initAuthArgs, {
+        apiKey: API_KEY,
+        apiSecret: API_SECRET
+      })
     })
 
     it('updates auth args with setAuthArgs', async () => {

--- a/test/lib/ws2_manager.js
+++ b/test/lib/ws2_manager.js
@@ -189,8 +189,7 @@ describe('WS2Manager', () => {
       m._sockets = [{
         ws: {
           isAuthenticated: () => false,
-          setAPICredentials: (key, secret) => { cred = `${key}:${secret}` },
-          updateAuthArgs: () => {},
+          updateAuthArgs: ({ apiKey: key, apiSecret: secret }) => { cred = `${key}:${secret}` },
           auth: () => {
             assert.strictEqual(cred, '41:42')
             done()
@@ -285,8 +284,8 @@ describe('WS2Manager', () => {
       const { ws } = s
 
       ws.auth = async () => {
-        assert.strictEqual(ws._apiKey, 'key', 'api key not set')
-        assert.strictEqual(ws._apiSecret, 'secret', 'api secret not set')
+        assert.strictEqual(ws._authArgs.apiKey, 'key', 'api key not set')
+        assert.strictEqual(ws._authArgs.apiSecret, 'secret', 'api secret not set')
 
         await ws.close()
         done()


### PR DESCRIPTION
### Description:
The problem is that while saving the creds in Settings, the API key and secret were not dynamically changed in WS2. When reconnecting, it still used the old ones. 

Depends on: https://github.com/bitfinexcom/bfx-api-mock-srv/pull/48

### Fixes:
- Fix ignored authArgs on reconnect

https://user-images.githubusercontent.com/70510980/115753939-62a6e180-a3a4-11eb-8517-df1ae0b9e258.mov
